### PR TITLE
Implement push_back_range for String List

### DIFF
--- a/src/modules/roc_core/string_list.cpp
+++ b/src/modules/roc_core/string_list.cpp
@@ -86,6 +86,28 @@ bool StringList::push_back_unique(const char* str) {
     return push_back(str);
 }
 
+bool StringList::push_back_range(const char* begin, const char* end) {
+    if (begin == NULL || end == NULL) {
+        roc_panic("stringlist: string is null");
+    }
+
+    const size_t cur_sz = data_.size();
+    const size_t add_sz = (size_t)(end - begin) + 1;
+
+    if (!grow_(cur_sz + add_sz)) {
+        return false;
+    }
+
+    if (!data_.resize(cur_sz + add_sz)) {
+        return false;
+    }
+
+    memcpy(&data_[cur_sz], begin, add_sz - 1);
+    size_++;
+
+    return true;
+}
+
 void StringList::clear() {
     data_.resize(0);
     size_ = 0;

--- a/src/modules/roc_core/string_list.cpp
+++ b/src/modules/roc_core/string_list.cpp
@@ -60,21 +60,7 @@ bool StringList::push_back(const char* str) {
         roc_panic("stringlist: string is null");
     }
 
-    const size_t cur_sz = data_.size();
-    const size_t add_sz = strlen(str) + 1;
-
-    if (!grow_(cur_sz + add_sz)) {
-        return false;
-    }
-
-    if (!data_.resize(cur_sz + add_sz)) {
-        return false;
-    }
-
-    memcpy(&data_[cur_sz], str, add_sz);
-    size_++;
-
-    return true;
+    return push_back_range(str, str + strlen(str));
 }
 
 bool StringList::push_back_unique(const char* str) {
@@ -87,7 +73,7 @@ bool StringList::push_back_unique(const char* str) {
 }
 
 bool StringList::push_back_range(const char* begin, const char* end) {
-    if (begin == NULL || end == NULL) {
+    if (begin == NULL || end == NULL || begin > end) {
         roc_panic("stringlist: string is null");
     }
 
@@ -103,6 +89,7 @@ bool StringList::push_back_range(const char* begin, const char* end) {
     }
 
     memcpy(&data_[cur_sz], begin, add_sz - 1);
+    data_[cur_sz + add_sz - 1] = '\0';
     size_++;
 
     return true;

--- a/src/modules/roc_core/string_list.h
+++ b/src/modules/roc_core/string_list.h
@@ -56,6 +56,13 @@ public:
     //!  false if allocation failed.
     bool push_back_unique(const char* str);
 
+    //! Append string from a range to the list.
+    //! @remarks
+    //!  Reallocates memory if necessary.
+    //! @returns
+    //!  false if allocation failed.
+    bool push_back_range(const char* begin, const char* end);
+
     //! Clear the list.
     void clear();
 

--- a/src/tests/roc_core/test_string_list.cpp
+++ b/src/tests/roc_core/test_string_list.cpp
@@ -144,6 +144,27 @@ TEST(string_list, uniq) {
     CHECK(str == NULL);
 }
 
+TEST(string_list, push_back_range) {
+    StringList sl(allocator);
+
+    LONGS_EQUAL(0, sl.size());
+    CHECK(sl.front() == NULL);
+
+    const char* str = "foobar";
+    const char* end_1 = str + 3;
+    const char* end_2 = str + 6;
+
+    CHECK(sl.push_back_range(str, end_1));
+
+    LONGS_EQUAL(1, sl.size());
+    STRCMP_EQUAL("foo", sl.front());
+
+    CHECK(sl.push_back_range(end_1, end_2));
+
+    LONGS_EQUAL(2, sl.size());
+    STRCMP_EQUAL("bar", sl.nextof(sl.front()));
+}
+
 TEST(string_list, clear) {
     StringList sl(allocator);
 


### PR DESCRIPTION
Implementation of the method push_back_range which appends a string from two pointers begin and end to a string list.
Used in #300 .