### PR TITLE
Replaced pthread_mutex with pthread_key_create

### DIFF
--- a/src/modules/roc_core/target_posix/roc_core/fast_random.cpp
+++ b/src/modules/roc_core/target_posix/roc_core/fast_random.cpp
@@ -58,7 +58,7 @@ uint32_t fast_random(uint32_t from, uint32_t to) {
 
     pthread_once(&rand_key_once, do_init);
 
-    unsigned short *val = (unsigned short *) pthread_getspecific(rand_key);
+    unsigned short* val = (unsigned short*)pthread_getspecific(rand_key);
     if (val == NULL) {
         val = rand_seed;
         pthread_setspecific(rand_key, &rand_seed);


### PR DESCRIPTION
PR for issue #410 

Using rand_seed global variable as a local storage key value, this avoids the dependency of a destructor. 

pthread_key_delete is needed but I am not sure when to call it!