### PR TITLE
Don't define _POSIX_C_SOURCE for FreeBSD

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -741,7 +741,7 @@ subenvs = type('subenvs', (), subenv_attrs)
 env, subenvs = env.SConscript('3rdparty/SConscript',
                        duplicate=0, exports='env subenvs meta')
 
-if 'target_posix' in env['ROC_TARGETS'] and meta.platform not in ['darwin']:
+if 'target_posix' in env['ROC_TARGETS'] and meta.platform not in ['darwin', 'unix']:
     env.Append(CPPDEFINES=[('_POSIX_C_SOURCE', '200809')])
 
 if meta.platform in ['linux', 'unix']:


### PR DESCRIPTION
Under FreeBSD, defining `_POSIX_C_SOURCE` causes `__BSD_VISIBLE`, `__XSI_VISIBLE`, `__POSIX_VISIBLE`, and `_POSIX_SOURCE` to be set such that various important bits are not available. This includes the macros `IN_MULTICAST`, `MSG_DONTWAIT`, and `M_PI`, and the struct `sigaction`. The FreeBSD man page `standards(5)` describes this in much detail, but what it comes down to is that for relatively normal code that macro shouldn't be defined at all.

Seems plausible that this applies to Net and OpenBSD as well, but TBD.