### PR TITLE
Error handling for invalid compiler version

### DIFF
--- a/scripts/scons_plugin/parsers.py
+++ b/scripts/scons_plugin/parsers.py
@@ -72,9 +72,10 @@ def ParseCompilerVersion(env, compiler):
                     if m:
                         return m.group(1)
 
-            return None
-        except:
-            pass
+            raise Exception("Invalid compiler version.")
+        except Exception as e:
+            print(e)
+            raise e
 
     ver = getverstr()
     if ver:


### PR DESCRIPTION
Disabling return none for ParseCompilerVersion function in parsers.py