### PR TITLE
GH-364 small scripts refactoring & comments

### DIFF
--- a/3rdparty/SConscript
+++ b/3rdparty/SConscript
@@ -4,7 +4,7 @@ Import('env', 'subenvs', 'meta')
 
 # default versions for downloaded third-party libraries
 thirdparty_versions = {
-    # lib
+    # libs
     'alsa':             '1.0.29',
     'json-c':           '0.12-20140410',
     'libatomic_ops':    '7.6.10',
@@ -390,6 +390,8 @@ elif 'google-benchmark' in system_dependencies:
         subenvs.tests.AppendUnique(CPPDEFINES=['ROC_BENCHMARK_USE_ACCESSORS'])
 
     subenvs.tests = conf.Finish()
+
+# end of deps
 
 return_value = (env, subenvs)
 Return('return_value')

--- a/scripts/ci_checks/android/linux.sh
+++ b/scripts/ci_checks/android/linux.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 scons -Q \

--- a/scripts/ci_checks/android/macos_build.sh
+++ b/scripts/ci_checks/android/macos_build.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 build="darwin-x86_64"

--- a/scripts/ci_checks/android/macos_deps.sh
+++ b/scripts/ci_checks/android/macos_deps.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 brew install \

--- a/scripts/ci_checks/docker.sh
+++ b/scripts/ci_checks/docker.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 if [ -z "${CI:-}" ]; then

--- a/scripts/ci_checks/linux-arm/aarch64-linux-gnu-gcc-7.4.sh
+++ b/scripts/ci_checks/linux-arm/aarch64-linux-gnu-gcc-7.4.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 toolchain="aarch64-linux-gnu"

--- a/scripts/ci_checks/linux-arm/arm-bcm2708hardfp-linux-gnueabi-gcc-4.7.sh
+++ b/scripts/ci_checks/linux-arm/arm-bcm2708hardfp-linux-gnueabi-gcc-4.7.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 toolchain="arm-bcm2708hardfp-linux-gnueabi"

--- a/scripts/ci_checks/linux-arm/arm-linux-gnueabihf-gcc-4.9.sh
+++ b/scripts/ci_checks/linux-arm/arm-linux-gnueabihf-gcc-4.9.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 toolchain="arm-linux-gnueabihf"

--- a/scripts/ci_checks/linux-checks/check-formatting.sh
+++ b/scripts/ci_checks/linux-checks/check-formatting.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 scons -Q fmt

--- a/scripts/ci_checks/linux-checks/conditional-build.sh
+++ b/scripts/ci_checks/linux-checks/conditional-build.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 # optional dependencies: none, optional targets: none

--- a/scripts/ci_checks/linux-checks/debug-build.sh
+++ b/scripts/ci_checks/linux-checks/debug-build.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 # debug: yes, debug-3rdparty: no

--- a/scripts/ci_checks/linux-checks/sanitizers.sh
+++ b/scripts/ci_checks/linux-checks/sanitizers.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 # gcc

--- a/scripts/ci_checks/linux-checks/static-shared.sh
+++ b/scripts/ci_checks/linux-checks/static-shared.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 # shared: no, static: no, tests: no

--- a/scripts/ci_checks/linux-checks/valgrind.sh
+++ b/scripts/ci_checks/linux-checks/valgrind.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 # debug

--- a/scripts/ci_checks/linux-x86_64/alpine.sh
+++ b/scripts/ci_checks/linux-x86_64/alpine.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 scons -Q \

--- a/scripts/ci_checks/linux-x86_64/archlinux.sh
+++ b/scripts/ci_checks/linux-x86_64/archlinux.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 scons -Q \

--- a/scripts/ci_checks/linux-x86_64/centos.sh
+++ b/scripts/ci_checks/linux-x86_64/centos.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 scons -Q \

--- a/scripts/ci_checks/linux-x86_64/debian.sh
+++ b/scripts/ci_checks/linux-x86_64/debian.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 scons -Q \

--- a/scripts/ci_checks/linux-x86_64/fedora.sh
+++ b/scripts/ci_checks/linux-x86_64/fedora.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 scons -Q \

--- a/scripts/ci_checks/linux-x86_64/opensuse.sh
+++ b/scripts/ci_checks/linux-x86_64/opensuse.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 scons -Q \

--- a/scripts/ci_checks/linux-x86_64/ubuntu-14.04.sh
+++ b/scripts/ci_checks/linux-x86_64/ubuntu-14.04.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 for c in gcc-4.4 clang-3.4

--- a/scripts/ci_checks/linux-x86_64/ubuntu-16.04.sh
+++ b/scripts/ci_checks/linux-x86_64/ubuntu-16.04.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 for c in gcc-4.8 clang-3.7

--- a/scripts/ci_checks/linux-x86_64/ubuntu-18.04.sh
+++ b/scripts/ci_checks/linux-x86_64/ubuntu-18.04.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 for c in gcc-6 clang-6.0

--- a/scripts/ci_checks/linux-x86_64/ubuntu-20.04.sh
+++ b/scripts/ci_checks/linux-x86_64/ubuntu-20.04.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 for c in gcc-8 gcc-10 clang-8 clang-10

--- a/scripts/ci_checks/linux-x86_64/ubuntu-22.04.sh
+++ b/scripts/ci_checks/linux-x86_64/ubuntu-22.04.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 for c in gcc-11 gcc-12 clang-11 clang-14

--- a/scripts/ci_checks/macos/macos.sh
+++ b/scripts/ci_checks/macos/macos.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 brew install \

--- a/scripts/ci_checks/trigger.sh
+++ b/scripts/ci_checks/trigger.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
 set -euxo pipefail
 
 repo="$1"

--- a/scripts/scons_helpers/build-3rdparty.py
+++ b/scripts/scons_helpers/build-3rdparty.py
@@ -29,8 +29,16 @@ try:
 except:
     pass
 
+#
+# Variables for helpers.
+#
+
 printdir = os.path.abspath('.')
 devnull = open(os.devnull, 'w+')
+
+#
+# Helpers.
+#
 
 def mkpath(path):
     try:
@@ -516,6 +524,10 @@ def makeenv(envlist):
         ret.append(quote(e))
     return ' '.join(ret)
 
+#
+# Main.
+#
+
 if len(sys.argv) < 7:
     print("error: usage: 3rdparty.py workdir vendordir toolchain variant package deplist [env]",
           file=sys.stderr)
@@ -523,11 +535,15 @@ if len(sys.argv) < 7:
 
 workdir = os.path.abspath(sys.argv[1])
 vendordir = os.path.abspath(sys.argv[2])
-toolchain = sys.argv[3]
-variant = sys.argv[4]
-fullname = sys.argv[5]
-deplist = sys.argv[6].split(':')
-envlist = sys.argv[7:]
+toolchain = sys.argv[3]          # toolchain, e.g. 'x86_64-pc-linux-gnu'; may be empty string
+variant = sys.argv[4]            # 'debug' or 'release' variant should be built
+fullname = sys.argv[5]           # package's name and version, e.g. 'openssl-3.0.7-rc1'
+deplist = sys.argv[6].split(':') # list of 3rdparty dependencies names, e.g. 'ltdl:json-c'
+envlist = sys.argv[7:]           # build env variables, e.g. 'CC=gcc CXX=g++ LDFLAGS=...'
+
+if variant not in ['debug', 'release']:
+    print("error: argument 'variant' should be 'debug' or 'release'")
+    exit(1)
 
 env = dict()
 for e in envlist:
@@ -554,6 +570,10 @@ rmpath(commit_build_finished_file)
 mkpath(src_dir)
 
 os.chdir(build_dir)
+
+#
+# Recipes for particular targets.
+#
 
 if name == 'libuv':
     download('https://dist.libuv.org/dist/v%s/libuv-v%s.tar.gz' % (ver, ver),

--- a/scripts/update_authors.sh
+++ b/scripts/update_authors.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 function find_login() {
     local github_login="$(curl -s "https://api.github.com/search/users?q=$1" \


### PR DESCRIPTION
Replaced `/bin/bash` with a more portable shebang variant `/usr/bin/env bash`.