### PR TITLE
Add support for DESTDIR during installation

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -296,6 +296,7 @@ env.OverrideFromArgument('BREATHE_APIDOC', default='breathe-apidoc')
 env.PrependFromArgument('CPPFLAGS')
 env.PrependFromArgument('CXXFLAGS')
 env.PrependFromArgument('CFLAGS')
+env.PrependFromArgument('DESTDIR', default='/')
 env.PrependFromArgument('LINKFLAGS', names=['LINKFLAGS', 'LDFLAGS'])
 env.PrependFromArgument('STRIPFLAGS')
 

--- a/docs/SConscript
+++ b/docs/SConscript
@@ -77,5 +77,5 @@ if GetOption('enable_sphinx'):
 doc_env.AlwaysBuild(doc_env.Alias('docs', ['doxygen', 'sphinx']))
 
 for manpage in doc_env.GlobFiles('#docs/sphinx/manuals/*.rst'):
-    doc_env.AddDistFile(GetOption('mandir'), '#docs/man/%s.1' %
+    doc_env.AddDistFile(doc_env["DESTDIR"] + GetOption('mandir'), '#docs/man/%s.1' %
                         manpage.srcnode().name.replace('.rst', '').replace('_', '-'))

--- a/src/SConscript
+++ b/src/SConscript
@@ -88,14 +88,14 @@ if not GetOption('disable_shared') or GetOption('enable_static') or GetOption('e
         public_api_targets += [install_target]
         public_api_targets += symlinks
 
-        env.AddDistFile(env['ROC_SYSTEM_LIBDIR'], install_target)
+        env.AddDistFile(env['DESTDIR'] + env['ROC_SYSTEM_LIBDIR'], install_target)
 
         if env.NeedsFixupSharedLibrary():
             env.AddDistAction(env.FixupSharedLibrary(
                 os.path.join(env['ROC_SYSTEM_LIBDIR'], install_target[0].name)))
 
         for lnk in symlinks:
-            env.AddDistFile(env['ROC_SYSTEM_LIBDIR'], lnk)
+            env.AddDistFile(env['DESTDIR'] + env['ROC_SYSTEM_LIBDIR'], lnk)
 
     if GetOption('enable_static'):
         thirdparty_libs = libs_env.GetThirdPartyStaticLibs()
@@ -123,13 +123,13 @@ if not GetOption('disable_shared') or GetOption('enable_static') or GetOption('e
         install_target = env.Install(env['ROC_BINDIR'], libroc_static)
         public_api_targets += [install_target]
 
-        env.AddDistFile(env['ROC_SYSTEM_LIBDIR'], install_target)
+        env.AddDistFile(env['DESTDIR'] + env['ROC_SYSTEM_LIBDIR'], install_target)
 
     if not GetOption('disable_shared') or GetOption('enable_static'):
         env.Alias('public_api', public_api_targets, env.Action(''))
         env.AlwaysBuild('public_api')
 
-        env.AddDistFile(env['ROC_SYSTEM_INCDIR'], '#src/public_api/include/roc')
+        env.AddDistFile(env['DESTDIR'] + env['ROC_SYSTEM_INCDIR'], '#src/public_api/include/roc')
 
         if 'PKG_CONFIG_PATH' in env.Dictionary():
             pc_file = env.GeneratePkgConfig(
@@ -141,7 +141,7 @@ if not GetOption('disable_shared') or GetOption('enable_static') or GetOption('e
                 desc='Real-time audio streaming over the network.',
                 url='https://roc-streaming.org',
                 version=env['ROC_VERSION'])
-            env.AddDistFile(env['ROC_SYSTEM_PCDIR'], pc_file)
+            env.AddDistFile(env['DESTDIR'] + env['ROC_SYSTEM_PCDIR'], pc_file)
 
 if GetOption('enable_examples'):
     examples_env = subenvs.examples.Clone()
@@ -197,7 +197,7 @@ if not GetOption('disable_tools'):
         env.Alias(exe_name, [target], env.Action(''))
         env.AlwaysBuild(exe_name)
 
-        env.AddDistFile(env['ROC_SYSTEM_BINDIR'], target)
+        env.AddDistFile(env['DESTDIR'] + env['ROC_SYSTEM_BINDIR'], target)
 
 if GetOption('enable_tests') or GetOption('enable_benchmarks'):
     common_test_env = subenvs.tests.Clone()


### PR DESCRIPTION
Support the use of the commonly used DESTDIR environment variable during installation, which is prepended to the target installation path of all files being installed.

Fixes #502 