### PR TITLE
Allow to enable SO_REUSEADDR via API and CLI

### DIFF
--- a/docs/man/roc-recv.1
+++ b/docs/man/roc-recv.1
@@ -75,6 +75,9 @@ Local control endpoint
 .BI \-\-miface\fB= MIFACE
 IPv4 or IPv6 address of the network interface on which to join the multicast group
 .TP
+.B  \-\-reuseaddr
+enable SO_REUSEADDR when binding sockets
+.TP
 .BI \-\-sess\-latency\fB= STRING
 Session target latency, TIME units
 .TP
@@ -245,6 +248,15 @@ It\(aqs not possible to receive multicast traffic without joining a multicast gr
 Multiple sets of endpoints can be specified to retrieve media from multiple addresses.
 .sp
 Such endpoint sets are called slots. All slots should have the same set of endpoint types (source, repair, etc) and should use the same protocols for them. All slots should also have their own multicast interface option, if it\(aqs used.
+.SS SO_REUSEADDR
+.sp
+If \fB\-\-reuseaddr\fP option is provided, \fBSO_REUSEADDR\fP socket option will be enabled for all sockets (by default it\(aqs enabled only for multicast sockets).
+.sp
+For TCP, it allows immediately reusing recently closed socket in TIME_WAIT state, which may be useful you want to be able to restart server quickly.
+.sp
+For UDP, it allows multiple processes to bind to the same address, which may be useful if you\(aqre using systemd socket activation.
+.sp
+Regardless of the option, \fBSO_REUSEADDR\fP is always disabled when binding to ephemeral port.
 .SS Backup audio
 .sp
 If \fB\-\-backup\fP option is given, it defines input audio device or file which will be played when there are no connected sessions. If it\(aqs not given, silence is played instead.

--- a/docs/man/roc-send.1
+++ b/docs/man/roc-send.1
@@ -66,6 +66,9 @@ Remote repair endpoint
 .BI \-c\fP,\fB  \-\-control\fB= ENDPOINT_URI
 Remote control endpoint
 .TP
+.B  \-\-reuseaddr
+enable SO_REUSEADDR when binding sockets
+.TP
 .BI \-\-nbsrc\fB= INT
 Number of source packets in FEC block
 .TP
@@ -213,6 +216,15 @@ For example, the file named \fB/foo/bar%/[baz]\fP may be specified using either 
 Multiple sets of endpoints can be specified to send media to multiple addresses.
 .sp
 Such endpoint sets are called slots. All slots should have the same set of endpoint types (source, repair, etc) and should use the same protocols for them.
+.SS SO_REUSEADDR
+.sp
+If \fB\-\-reuseaddr\fP option is provided, \fBSO_REUSEADDR\fP socket option will be enabled for all sockets.
+.sp
+For TCP, it allows immediately reusing recently closed socket in TIME_WAIT state, which may be useful you want to be able to restart server quickly.
+.sp
+For UDP, it allows multiple processes to bind to the same address, which may be useful if you\(aqre using systemd socket activation.
+.sp
+Regardless of the option, \fBSO_REUSEADDR\fP is always disabled when binding to ephemeral port.
 .SS Time units
 .INDENT 0.0
 .TP

--- a/docs/sphinx/api/reference.rst
+++ b/docs/sphinx/api/reference.rst
@@ -39,6 +39,8 @@ roc_sender
 
 .. doxygenfunction:: roc_sender_set_outgoing_address
 
+.. doxygenfunction:: roc_sender_set_reuseaddr
+
 .. doxygenfunction:: roc_sender_connect
 
 .. doxygenfunction:: roc_sender_write
@@ -57,6 +59,8 @@ roc_receiver
 .. doxygenfunction:: roc_receiver_open
 
 .. doxygenfunction:: roc_receiver_set_multicast_group
+
+.. doxygenfunction:: roc_receiver_set_reuseaddr
 
 .. doxygenfunction:: roc_receiver_bind
 

--- a/docs/sphinx/manuals/roc_recv.rst
+++ b/docs/sphinx/manuals/roc_recv.rst
@@ -26,6 +26,7 @@ Options
 -r, --repair=ENDPOINT_URI    Local repair endpoint
 -c, --control=ENDPOINT_URI   Local control endpoint
 --miface=MIFACE              IPv4 or IPv6 address of the network interface on which to join the multicast group
+--reuseaddr                  enable SO_REUSEADDR when binding sockets
 --sess-latency=STRING        Session target latency, TIME units
 --min-latency=STRING         Session minimum latency, TIME units
 --max-latency=STRING         Session maximum latency, TIME units
@@ -136,6 +137,17 @@ Multiple slots
 Multiple sets of endpoints can be specified to retrieve media from multiple addresses.
 
 Such endpoint sets are called slots. All slots should have the same set of endpoint types (source, repair, etc) and should use the same protocols for them. All slots should also have their own multicast interface option, if it's used.
+
+SO_REUSEADDR
+------------
+
+If ``--reuseaddr`` option is provided, ``SO_REUSEADDR`` socket option will be enabled for all sockets (by default it's enabled only for multicast sockets).
+
+For TCP, it allows immediately reusing recently closed socket in TIME_WAIT state, which may be useful you want to be able to restart server quickly.
+
+For UDP, it allows multiple processes to bind to the same address, which may be useful if you're using systemd socket activation.
+
+Regardless of the option, ``SO_REUSEADDR`` is always disabled when binding to ephemeral port.
 
 Backup audio
 ------------

--- a/docs/sphinx/manuals/roc_send.rst
+++ b/docs/sphinx/manuals/roc_send.rst
@@ -23,6 +23,7 @@ Options
 -s, --source=ENDPOINT_URI   Remote source endpoint
 -r, --repair=ENDPOINT_URI   Remote repair endpoint
 -c, --control=ENDPOINT_URI  Remote control endpoint
+--reuseaddr                 enable SO_REUSEADDR when binding sockets
 --nbsrc=INT                 Number of source packets in FEC block
 --nbrpr=INT                 Number of repair packets in FEC block
 --packet-length=STRING      Outgoing packet length, TIME units
@@ -118,6 +119,17 @@ Multiple slots
 Multiple sets of endpoints can be specified to send media to multiple addresses.
 
 Such endpoint sets are called slots. All slots should have the same set of endpoint types (source, repair, etc) and should use the same protocols for them.
+
+SO_REUSEADDR
+------------
+
+If ``--reuseaddr`` option is provided, ``SO_REUSEADDR`` socket option will be enabled for all sockets.
+
+For TCP, it allows immediately reusing recently closed socket in TIME_WAIT state, which may be useful you want to be able to restart server quickly.
+
+For UDP, it allows multiple processes to bind to the same address, which may be useful if you're using systemd socket activation.
+
+Regardless of the option, ``SO_REUSEADDR`` is always disabled when binding to ephemeral port.
 
 Time units
 ----------

--- a/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_receiver_port.cpp
+++ b/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_receiver_port.cpp
@@ -61,7 +61,8 @@ bool UdpReceiverPort::open() {
     handle_initialized_ = true;
 
     unsigned flags = 0;
-    if (config_.bind_address.multicast() && config_.bind_address.port() > 0) {
+    if ((config_.reuseaddr || config_.bind_address.multicast())
+        && config_.bind_address.port() > 0) {
         flags |= UV_UDP_REUSEADDR;
     }
 

--- a/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_receiver_port.h
+++ b/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_receiver_port.h
@@ -38,7 +38,13 @@ struct UdpReceiverConfig {
     //! with given address. May be "0.0.0.0" or "[::]" to join on all interfaces.
     char multicast_interface[64];
 
-    UdpReceiverConfig() {
+    //! If set, enable SO_REUSEADDR when binding socket to non-ephemeral port.
+    //! If not set, SO_REUSEADDR is enabled only for multicast sockets when
+    //! binding to non-ephemeral port.
+    bool reuseaddr;
+
+    UdpReceiverConfig()
+        : reuseaddr(false) {
         multicast_interface[0] = '\0';
     }
 };

--- a/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_sender_port.cpp
+++ b/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_sender_port.cpp
@@ -77,12 +77,18 @@ bool UdpSenderPort::open() {
     handle_.data = this;
     handle_initialized_ = true;
 
+    unsigned flags = 0;
+    if (config_.reuseaddr && config_.bind_address.port() > 0) {
+        flags |= UV_UDP_REUSEADDR;
+    }
+
     int bind_err = UV_EINVAL;
     if (address_.family() == address::Family_IPv6) {
-        bind_err = uv_udp_bind(&handle_, config_.bind_address.saddr(), UV_UDP_IPV6ONLY);
+        bind_err =
+            uv_udp_bind(&handle_, config_.bind_address.saddr(), flags | UV_UDP_IPV6ONLY);
     }
     if (bind_err == UV_EINVAL || bind_err == UV_ENOTSUP) {
-        bind_err = uv_udp_bind(&handle_, config_.bind_address.saddr(), 0);
+        bind_err = uv_udp_bind(&handle_, config_.bind_address.saddr(), flags);
     }
     if (bind_err != 0) {
         roc_log(LogError, "udp sender: %s: uv_udp_bind(): [%s] %s", descriptor(),

--- a/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_sender_port.h
+++ b/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_sender_port.h
@@ -33,13 +33,18 @@ struct UdpSenderConfig {
     //! interfaces. If port is zero, a random free port is selected.
     address::SocketAddr bind_address;
 
+    //! If set, enable SO_REUSEADDR when binding socket to non-ephemeral port.
+    //! If not set, SO_REUSEADDR is not enabled.
+    bool reuseaddr;
+
     //! If true, allow non-blocking writes directly in write() method.
     //! If non-blocking write can't be performed, sender falls back to
     //! regular asynchronous write.
     bool non_blocking_enabled;
 
     UdpSenderConfig()
-        : non_blocking_enabled(true) {
+        : reuseaddr(false)
+        , non_blocking_enabled(true) {
     }
 
     //! Check two configs for equality.

--- a/src/internal_modules/roc_peer/receiver.cpp
+++ b/src/internal_modules/roc_peer/receiver.cpp
@@ -128,6 +128,42 @@ bool Receiver::set_multicast_group(size_t slot_index,
     return true;
 }
 
+bool Receiver::set_reuseaddr(size_t slot_index, address::Interface iface, bool enabled) {
+    core::Mutex::Lock lock(mutex_);
+
+    roc_panic_if_not(valid());
+
+    roc_panic_if(iface < 0);
+    roc_panic_if(iface >= (int)address::Iface_Max);
+
+    roc_log(LogDebug,
+            "receiver peer: setting reuseaddr option for %s interface of slot %lu to %d",
+            address::interface_to_str(iface), (unsigned long)slot_index, (int)enabled);
+
+    Slot* slot = get_slot_(slot_index);
+    if (!slot) {
+        roc_log(LogError,
+                "receiver peer:"
+                " can't set reuseaddr option for %s interface of slot %lu:"
+                " can't create slot",
+                address::interface_to_str(iface), (unsigned long)slot_index);
+        return false;
+    }
+
+    if (slot->ports[iface].handle) {
+        roc_log(LogError,
+                "receiver peer:"
+                " can't set reuseaddr option for %s interface of slot %lu:"
+                " interface is already bound",
+                address::interface_to_str(iface), (unsigned long)slot_index);
+        return false;
+    }
+
+    slot->ports[iface].config.reuseaddr = enabled;
+
+    return true;
+}
+
 bool Receiver::bind(size_t slot_index,
                     address::Interface iface,
                     address::EndpointUri& uri) {

--- a/src/internal_modules/roc_peer/receiver.h
+++ b/src/internal_modules/roc_peer/receiver.h
@@ -41,6 +41,9 @@ public:
     //! Set multicast interface address for given endpoint type.
     bool set_multicast_group(size_t slot_index, address::Interface iface, const char* ip);
 
+    //! Set reuseaddr option for given endpoint type.
+    bool set_reuseaddr(size_t slot_index, address::Interface iface, bool enabled);
+
     //! Bind peer to local endpoint.
     bool bind(size_t slot_index, address::Interface iface, address::EndpointUri& uri);
 

--- a/src/internal_modules/roc_peer/sender.h
+++ b/src/internal_modules/roc_peer/sender.h
@@ -43,6 +43,9 @@ public:
     bool
     set_outgoing_address(size_t slot_index, address::Interface iface, const char* ip);
 
+    //! Set reuseaddr option for given endpoint type.
+    bool set_reuseaddr(size_t slot_index, address::Interface iface, bool enabled);
+
     //! Connect peer to remote endpoint.
     bool
     connect(size_t slot_index, address::Interface iface, const address::EndpointUri& uri);

--- a/src/public_api/include/roc/receiver.h
+++ b/src/public_api/include/roc/receiver.h
@@ -236,6 +236,42 @@ ROC_API int roc_receiver_set_multicast_group(roc_receiver* receiver,
                                              roc_interface iface,
                                              const char* ip);
 
+/** Set receiver interface address reuse option.
+ *
+ * Optional.
+ *
+ * When set to true, SO_REUSEADDR is enabled for interface socket, regardless of socket
+ * type, unless binding to ephemeral port (port explicitly set to zero).
+ *
+ * When set to false, SO_REUSEADDR is enabled only for multicast sockets, unless binding
+ * to ephemeral port (port explicitly set to zero).
+ *
+ * By default set to false.
+ *
+ * For TCP-based protocols, SO_REUSEADDR allows immediate reuse of recently closed socket
+ * in TIME_WAIT state, which may be useful you want to be able to restart server quickly.
+ *
+ * For UDP-based protocols, SO_REUSEADDR allows multiple processes to bind to the same
+ * address, which may be useful if you're using socket activation mechanism.
+ *
+ * Automatically initializes slot with given index if it's used first time.
+ *
+ * **Parameters**
+ *  - \p receiver should point to an opened receiver
+ *  - \p slot specifies the receiver slot
+ *  - \p iface specifies the receiver interface
+ *  - \p enabled should be 0 or 1
+ *
+ * **Returns**
+ *  - returns zero if the multicast group was successfully set
+ *  - returns a negative value if the arguments are invalid
+ *  - returns a negative value if an error occurred
+ */
+ROC_API int roc_receiver_set_reuseaddr(roc_receiver* receiver,
+                                       roc_slot slot,
+                                       roc_interface iface,
+                                       int enabled);
+
 /** Bind the receiver interface to a local endpoint.
  *
  * Checks that the endpoint is valid and supported by the interface, allocates

--- a/src/public_api/include/roc/sender.h
+++ b/src/public_api/include/roc/sender.h
@@ -203,6 +203,42 @@ ROC_API int roc_sender_set_outgoing_address(roc_sender* sender,
                                             roc_interface iface,
                                             const char* ip);
 
+/** Set sender interface address reuse option.
+ *
+ * Optional.
+ *
+ * When set to true, SO_REUSEADDR is enabled for interface socket, regardless of socket
+ * type, unless binding to ephemeral port (port explicitly set to zero).
+ *
+ * When set to false, SO_REUSEADDR is enabled only for multicast sockets, unless binding
+ * to ephemeral port (port explicitly set to zero).
+ *
+ * By default set to false.
+ *
+ * For TCP-based protocols, SO_REUSEADDR allows immediate reuse of recently closed socket
+ * in TIME_WAIT state, which may be useful you want to be able to restart server quickly.
+ *
+ * For UDP-based protocols, SO_REUSEADDR allows multiple processes to bind to the same
+ * address, which may be useful if you're using socket activation mechanism.
+ *
+ * Automatically initializes slot with given index if it's used first time.
+ *
+ * **Parameters**
+ *  - \p sender should point to an opened sender
+ *  - \p slot specifies the sender slot
+ *  - \p iface specifies the sender interface
+ *  - \p enabled should be 0 or 1
+ *
+ * **Returns**
+ *  - returns zero if the multicast group was successfully set
+ *  - returns a negative value if the arguments are invalid
+ *  - returns a negative value if an error occurred
+ */
+ROC_API int roc_sender_set_reuseaddr(roc_sender* sender,
+                                     roc_slot slot,
+                                     roc_interface iface,
+                                     int enabled);
+
 /** Connect the sender interface to a remote receiver endpoint.
  *
  * Checks that the endpoint is valid and supported by the interface, allocates

--- a/src/public_api/src/receiver.cpp
+++ b/src/public_api/src/receiver.cpp
@@ -95,6 +95,39 @@ int roc_receiver_set_multicast_group(roc_receiver* receiver,
     return 0;
 }
 
+int roc_receiver_set_reuseaddr(roc_receiver* receiver,
+                               roc_slot slot,
+                               roc_interface iface,
+                               int enabled) {
+    if (!receiver) {
+        roc_log(LogError,
+                "roc_receiver_set_reuseaddr: invalid arguments: receiver is null");
+        return -1;
+    }
+
+    peer::Receiver* imp_receiver = (peer::Receiver*)receiver;
+
+    address::Interface imp_iface;
+    if (!api::interface_from_user(imp_iface, iface)) {
+        roc_log(LogError, "roc_receiver_set_reuseaddr: invalid arguments: bad interface");
+        return -1;
+    }
+
+    if (enabled != 0 && enabled != 1) {
+        roc_log(
+            LogError,
+            "roc_receiver_set_reuseaddr: invalid arguments: enabled should be 0 or 1");
+        return -1;
+    }
+
+    if (!imp_receiver->set_reuseaddr(slot, imp_iface, (bool)enabled)) {
+        roc_log(LogError, "roc_receiver_set_reuseaddr: operation failed");
+        return -1;
+    }
+
+    return 0;
+}
+
 int roc_receiver_bind(roc_receiver* receiver,
                       roc_slot slot,
                       roc_interface iface,

--- a/src/public_api/src/sender.cpp
+++ b/src/public_api/src/sender.cpp
@@ -95,6 +95,37 @@ int roc_sender_set_outgoing_address(roc_sender* sender,
     return 0;
 }
 
+int roc_sender_set_reuseaddr(roc_sender* sender,
+                             roc_slot slot,
+                             roc_interface iface,
+                             int enabled) {
+    if (!sender) {
+        roc_log(LogError, "roc_sender_set_reuseaddr: invalid arguments: sender is null");
+        return -1;
+    }
+
+    peer::Sender* imp_sender = (peer::Sender*)sender;
+
+    address::Interface imp_iface;
+    if (!api::interface_from_user(imp_iface, iface)) {
+        roc_log(LogError, "roc_sender_set_reuseaddr: invalid arguments: bad interface");
+        return -1;
+    }
+
+    if (enabled != 0 && enabled != 1) {
+        roc_log(LogError,
+                "roc_sender_set_reuseaddr: invalid arguments: enabled should be 0 or 1");
+        return -1;
+    }
+
+    if (!imp_sender->set_reuseaddr(slot, imp_iface, (bool)enabled)) {
+        roc_log(LogError, "roc_sender_set_reuseaddr: operation failed");
+        return -1;
+    }
+
+    return 0;
+}
+
 int roc_sender_connect(roc_sender* sender,
                        roc_slot slot,
                        roc_interface iface,

--- a/src/tools/roc_recv/cmdline.ggo
+++ b/src/tools/roc_recv/cmdline.ggo
@@ -28,6 +28,8 @@ section "Options"
       "IPv4 or IPv6 address of the network interface on which to join the multicast group"
       typestr="MIFACE" string multiple optional
 
+    option "reuseaddr" - "enable SO_REUSEADDR when binding sockets" optional
+
     option "sess-latency" - "Session target latency, TIME units"
         string optional
 

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -406,7 +406,15 @@ int main(int argc, char** argv) {
         if (args.miface_given) {
             if (!receiver.set_multicast_group(slot, address::Iface_AudioSource,
                                               args.miface_arg[slot])) {
-                roc_log(LogError, "can't set multicast group: %s", args.miface_arg[slot]);
+                roc_log(LogError, "can't set multicast group for --source endpoint: %s",
+                        args.miface_arg[slot]);
+                return 1;
+            }
+        }
+
+        if (args.reuseaddr_given) {
+            if (!receiver.set_reuseaddr(slot, address::Iface_AudioSource, true)) {
+                roc_log(LogError, "can't set reuseaddr option for --source endpoint");
                 return 1;
             }
         }
@@ -429,7 +437,15 @@ int main(int argc, char** argv) {
         if (args.miface_given) {
             if (!receiver.set_multicast_group(slot, address::Iface_AudioRepair,
                                               args.miface_arg[slot])) {
-                roc_log(LogError, "can't set multicast group: %s", args.miface_arg[slot]);
+                roc_log(LogError, "can't set multicast group for --repair endpoint: %s",
+                        args.miface_arg[slot]);
+                return 1;
+            }
+        }
+
+        if (args.reuseaddr_given) {
+            if (!receiver.set_reuseaddr(slot, address::Iface_AudioRepair, true)) {
+                roc_log(LogError, "can't set reuseaddr option for --repair endpoint");
                 return 1;
             }
         }
@@ -448,6 +464,13 @@ int main(int argc, char** argv) {
             roc_log(LogError, "can't parse --control endpoint: %s",
                     args.control_arg[slot]);
             return 1;
+        }
+
+        if (args.reuseaddr_given) {
+            if (!receiver.set_reuseaddr(slot, address::Iface_AudioControl, true)) {
+                roc_log(LogError, "can't set reuseaddr option for --control endpoint");
+                return 1;
+            }
         }
 
         if (!receiver.bind(slot, address::Iface_AudioControl, endpoint)) {

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -466,6 +466,15 @@ int main(int argc, char** argv) {
             return 1;
         }
 
+        if (args.miface_given) {
+            if (!receiver.set_multicast_group(slot, address::Iface_AudioControl,
+                                              args.miface_arg[slot])) {
+                roc_log(LogError, "can't set multicast group for --control endpoint: %s",
+                        args.miface_arg[slot]);
+                return 1;
+            }
+        }
+
         if (args.reuseaddr_given) {
             if (!receiver.set_reuseaddr(slot, address::Iface_AudioControl, true)) {
                 roc_log(LogError, "can't set reuseaddr option for --control endpoint");

--- a/src/tools/roc_send/cmdline.ggo
+++ b/src/tools/roc_send/cmdline.ggo
@@ -18,6 +18,8 @@ section "Options"
     option "control" c "Remote control endpoint" typestr="ENDPOINT_URI"
         string multiple optional
 
+    option "reuseaddr" - "enable SO_REUSEADDR when binding sockets" optional
+
     option "nbsrc" - "Number of source packets in FEC block"
         int optional
 

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -296,6 +296,13 @@ int main(int argc, char** argv) {
             return 1;
         }
 
+        if (args.reuseaddr_given) {
+            if (!sender.set_reuseaddr(slot, address::Iface_AudioSource, true)) {
+                roc_log(LogError, "can't set reuseaddr option for --source endpoint");
+                return 1;
+            }
+        }
+
         if (!sender.connect(slot, address::Iface_AudioSource, source_endpoint)) {
             roc_log(LogError, "can't connect sender to source endpoint");
             return 1;
@@ -309,6 +316,13 @@ int main(int argc, char** argv) {
                                          repair_endpoint)) {
             roc_log(LogError, "can't parse --repair endpoint: %s", args.repair_arg[slot]);
             return 1;
+        }
+
+        if (args.reuseaddr_given) {
+            if (!sender.set_reuseaddr(slot, address::Iface_AudioRepair, true)) {
+                roc_log(LogError, "can't set reuseaddr option for --repair endpoint");
+                return 1;
+            }
         }
 
         if (!sender.connect(slot, address::Iface_AudioRepair, repair_endpoint)) {
@@ -325,6 +339,13 @@ int main(int argc, char** argv) {
             roc_log(LogError, "can't parse --control endpoint: %s",
                     args.control_arg[slot]);
             return 1;
+        }
+
+        if (args.reuseaddr_given) {
+            if (!sender.set_reuseaddr(slot, address::Iface_AudioControl, true)) {
+                roc_log(LogError, "can't set reuseaddr option for --control endpoint");
+                return 1;
+            }
         }
 
         if (!sender.connect(slot, address::Iface_AudioControl, control_endpoint)) {


### PR DESCRIPTION
Add `--reuseaddr` to CLI and `roc_receiver_set_reuseaddr` + `roc_sender_set_reuseaddr` to API, which enable `SO_REUSEADDR` for non-ephemeral ports.

Closes #449. Related: #458.