### PR TITLE
Added version check to CI checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          
 
       - name: Build and test
         run: |
@@ -152,6 +153,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-tags: true
 
       - name: Build and test
         run: |
@@ -310,6 +312,34 @@ jobs:
       - name: Build and test
         run: |
           scripts/ci_checks/macos/${{ matrix.script }}.sh
+
+      - name: Handle failure
+        if: failure()
+        run: |
+          scripts/ci_checks/failure.sh
+
+  release-checks:
+    runs-on: ubuntu-latest
+
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - script: linux-checks/check-version
+
+    name: ${{ matrix.script }}
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-tags: true
+
+      - name: Build and test
+        run: |
+          scripts/ci_checks/${{ matrix.script }}.sh
 
       - name: Handle failure
         if: failure()

--- a/scripts/ci_checks/linux-checks/check-version.sh
+++ b/scripts/ci_checks/linux-checks/check-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+
+tagname="$(git tag -l | tail -n1)"
+
+header_tagname="v$(python3 scripts/scons_helpers/parse-version.py)"
+
+if [[ "$tagname" != "$header_tagname" ]]; then
+  echo >&2 
+  echo >&2"version check FAILED"
+  echo >&2"the git tag name and version declared in version.h is not the same"
+  echo >&2"${tagname} git version tag"
+  echo >&2"${header_tagname} header version tag"
+  echo >&2
+  exit 1
+fi
+
+echo "version check SUCCEEDED"
+echo 
+


### PR DESCRIPTION
This PR adds a version-check to CI checks. It takes the version fetched from git and from the file `version.h` and compares it.
https://github.com/roc-streaming/roc-toolkit/issues/497