### PR TITLE
Fixes timestamp mapping remixing tests

### DIFF
--- a/src/internal_modules/roc_audio/depacketizer.cpp
+++ b/src/internal_modules/roc_audio/depacketizer.cpp
@@ -112,9 +112,17 @@ Depacketizer::read_samples_(sample_t* buff_ptr, sample_t* buff_end, FrameInfo& i
 
             buff_ptr = read_missing_samples_(buff_ptr, buff_ptr + n_samples);
 
+            //           next_capture_ts_
+            //           next_timestamp
+            //                  ↓
+            // Packet           |-----------------|
+            //           timestamp_
+            //               ↓
+            // Frame      |----------------|
+            info.n_filled_samples += n_samples;
             if (!info.capture_ts && valid_capture_ts_) {
-                info.capture_ts =
-                    next_capture_ts_ - sample_spec_.samples_overall_2_ns(mis_samples);
+                info.capture_ts = next_capture_ts_
+                    - sample_spec_.samples_overall_2_ns(info.n_filled_samples);
             }
         }
 
@@ -124,12 +132,14 @@ Depacketizer::read_samples_(sample_t* buff_ptr, sample_t* buff_end, FrameInfo& i
 
             info.n_decoded_samples += n_samples;
             if (n_samples && !info.capture_ts && valid_capture_ts_) {
-                info.capture_ts = next_capture_ts_;
+                info.capture_ts = next_capture_ts_
+                    - sample_spec_.samples_overall_2_ns(info.n_filled_samples);
             }
             if (valid_capture_ts_) {
                 next_capture_ts_ += sample_spec_.samples_overall_2_ns(n_samples);
             }
 
+            info.n_filled_samples += n_samples;
             buff_ptr = new_buff_ptr;
         }
 
@@ -138,12 +148,14 @@ Depacketizer::read_samples_(sample_t* buff_ptr, sample_t* buff_end, FrameInfo& i
         const size_t n_samples = size_t(buff_end - buff_ptr);
 
         if (!info.capture_ts && valid_capture_ts_) {
-            info.capture_ts = next_capture_ts_;
+            info.capture_ts = next_capture_ts_
+                - sample_spec_.samples_overall_2_ns(info.n_filled_samples);
         }
         if (valid_capture_ts_) {
             next_capture_ts_ += sample_spec_.samples_overall_2_ns(n_samples);
         }
 
+        info.n_filled_samples += n_samples;
         return read_missing_samples_(buff_ptr, buff_end);
     }
 }

--- a/src/internal_modules/roc_audio/depacketizer.h
+++ b/src/internal_modules/roc_audio/depacketizer.h
@@ -60,6 +60,9 @@ private:
         // Number of samples decoded from packets into the frame.
         size_t n_decoded_samples;
 
+        // Number of samples filled out in the frame.
+        size_t n_filled_samples;
+
         // Number of packets dropped during frame construction.
         size_t n_dropped_packets;
 
@@ -68,6 +71,7 @@ private:
 
         FrameInfo()
             : n_decoded_samples(0)
+            , n_filled_samples(0)
             , n_dropped_packets(0)
             , capture_ts(0) {
         }

--- a/src/tests/roc_pipeline/test_helpers/packet_reader.h
+++ b/src/tests/roc_pipeline/test_helpers/packet_reader.h
@@ -69,9 +69,9 @@ public:
         abs_offset_ += samples_per_packet;
     }
 
-    void read_nonzero_packet(size_t samples_per_packet,
-                             const audio::SampleSpec& sample_spec,
-                             core::nanoseconds_t base_capture_ts = -1) {
+    packet::PacketPtr read_nonzero_packet(size_t samples_per_packet,
+                                          const audio::SampleSpec& sample_spec,
+                                          core::nanoseconds_t base_capture_ts = -1) {
         packet::PacketPtr pp = read_packet_();
 
         audio::sample_t samples[MaxSamples] = {};
@@ -86,6 +86,8 @@ public:
         }
         CHECK(non_zero > 0);
         abs_offset_ += samples_per_packet;
+
+        return pp;
     }
 
     void read_zero_packet(size_t samples_per_packet,
@@ -165,9 +167,9 @@ private:
                           core::nanoseconds_t base_ts) {
         CHECK(pkt.rtp());
 
-        if (base_ts < 0) {
+        if (base_ts == 0) {
             LONGS_EQUAL(0, pkt.rtp()->capture_timestamp);
-        } else {
+        } else if (base_ts > 0) {
             const core::nanoseconds_t capture_ts =
                 base_ts + sample_spec.samples_per_chan_2_ns(abs_offset_);
 

--- a/src/tests/roc_pipeline/test_helpers/utils.h
+++ b/src/tests/roc_pipeline/test_helpers/utils.h
@@ -15,6 +15,7 @@
 #include "roc_audio/sample.h"
 #include "roc_core/stddefs.h"
 #include "roc_core/time.h"
+#include "roc_pipeline/config.h"
 
 namespace roc {
 namespace pipeline {
@@ -24,7 +25,8 @@ namespace {
 
 const double SampleEpsilon = 0.00001;
 
-const core::nanoseconds_t TimestampEpsilon = core::Microsecond;
+const core::nanoseconds_t TimestampEpsilon =
+    (core::nanoseconds_t)(1. / DefaultSampleRate * core::Second);
 
 inline audio::sample_t nth_sample(uint8_t n) {
     return audio::sample_t(n) / 1024;

--- a/src/tests/roc_pipeline/test_receiver_source.cpp
+++ b/src/tests/roc_pipeline/test_receiver_source.cpp
@@ -1693,7 +1693,7 @@ TEST(receiver_source, timestamp_mapping_periodic_control_packets) {
     }
 }
 
-IGNORE_TEST(receiver_source, timestamp_mapping_remixing) {
+TEST(receiver_source, recv_timestamp_mapping_remixing) {
     enum {
         OutputRate = 48000,
         PacketRate = 44100,
@@ -1719,7 +1719,7 @@ IGNORE_TEST(receiver_source, timestamp_mapping_remixing) {
     CHECK(control_endpoint);
 
     test::PacketWriter packet_writer(arena, *packet_endpoint, rtp_composer, format_map,
-                                     packet_factory, byte_buffer_factory, PayloadType_Ch2,
+                                     packet_factory, byte_buffer_factory, PayloadType_Ch1,
                                      src1, dst1);
 
     test::ControlWriter control_writer(*control_endpoint, packet_factory,


### PR DESCRIPTION
#539

In `receiver_source` test `recv_timestamp_mapping_remixing` the failure was caused by the issue in **Depacketizer**. As you suggested (after my localization): [here](https://github.com/roc-streaming/roc-toolkit/issues/539#issuecomment-1712284093):

> We should check if Depacketizer correctly handles case when first packet for frame had zero CTS, and second packet for the same frame had non-zero CTS.
> 
> I think it's not covered right now.
> 
> We need a test for this and maybe a fix.



In `sender_sink` tests the issue is simple: Resampler backend throw away first n samples (N==latency), which was not properly reflected in `test::PacketReader`