### PR TITLE
gh-546: Support NTP 2036 year base

### DIFF
--- a/src/internal_modules/roc_packet/ntp.cpp
+++ b/src/internal_modules/roc_packet/ntp.cpp
@@ -16,32 +16,47 @@ namespace packet {
 
 namespace {
 
-// Number of seconds fron NTP epoch (1900-01-01) to Unix epoch (1970-01-01).
-// Equals to 70 years + 17 leap days.
-static uint64_t unix_epoch = uint64_t(70 * 365 + 17) * (24 * 60 * 60);
+// Number of seconds from NTP epoch (1900-01-01) to Unix epoch (1970-01-01).
+// Equals to 70 years with 17 leap days.
+static uint64_t UnixEpoch = uint64_t(70 * 365 + 17) * (24 * 3600);
+
+// Number of seconds from Unix epoch to NTP Era 1 (7 Feb 2036 6:28:16).
+// Equals to 66 years with 16 leap days, 37 days, 6 hours, 28 minutes and 16 seconds.
+// See RFC 2030.
+static uint64_t Era1 =
+    uint64_t(66 * 365 + 16 + 37) * (24 * 3600) + (6 * 3600) + (28 * 60) + 16;
 
 } // namespace
 
-bool ntp_equal_delta(ntp_timestamp_t a, ntp_timestamp_t b, ntp_timestamp_t delta) {
-    ntp_timestamp_t abs_error = std::max(a, b) - std::min(a, b);
-    return abs_error <= delta;
-}
-
 ntp_timestamp_t unix_2_ntp(core::nanoseconds_t unix_time) {
-    const core::nanoseconds_t ntp_time =
-        unix_time + (core::nanoseconds_t)unix_epoch * core::Second;
+    if (unix_time < (core::nanoseconds_t)Era1 * core::Second) {
+        // "normal" ntp (1968-2036)
+        const core::nanoseconds_t ntp_time =
+            unix_time + (core::nanoseconds_t)UnixEpoch * core::Second;
+        return nanoseconds_2_ntp(ntp_time);
+    }
 
+    // "era1" ntp (2036-2104)
+    const core::nanoseconds_t ntp_time =
+        unix_time - (core::nanoseconds_t)Era1 * core::Second;
     return nanoseconds_2_ntp(ntp_time);
 }
 
 core::nanoseconds_t ntp_2_unix(ntp_timestamp_t ntp_time) {
-    const ntp_timestamp_t unix_epoch_ntp = (unix_epoch << 32);
+    if (ntp_time & 0x8000000000000000ull) {
+        // "normal" ntp (1968-2036)
+        const ntp_timestamp_t unix_epoch_ntp = (UnixEpoch << 32);
 
-    if (ntp_time < unix_epoch_ntp) {
-        return -ntp_2_nanoseconds(unix_epoch_ntp - ntp_time);
+        if (ntp_time < unix_epoch_ntp) {
+            // negative unix time (1968-1970)
+            return -ntp_2_nanoseconds(unix_epoch_ntp - ntp_time);
+        }
+        return ntp_2_nanoseconds(ntp_time - unix_epoch_ntp);
     }
 
-    return ntp_2_nanoseconds(ntp_time - unix_epoch_ntp);
+    // "era1" ntp (2036-2104)
+    const ntp_timestamp_t era1_ntp = (Era1 << 32);
+    return ntp_2_nanoseconds(ntp_time + era1_ntp);
 }
 
 ntp_timestamp_t nanoseconds_2_ntp(core::nanoseconds_t ns_delta) {

--- a/src/internal_modules/roc_packet/ntp.h
+++ b/src/internal_modules/roc_packet/ntp.h
@@ -18,17 +18,21 @@ namespace roc {
 namespace packet {
 
 //! NTP timestamp.
-//! @remarks
-//!  Highest 32 bits - seconds since NTP epoch, lowest 32 bits - fractions of a second.
-//!  NTP epoch starts from January 1, 1900.
+//!
+//! Format:
+//!  - highest 32 bits - seconds since NTP epoch
+//!  - lowest 32 bits - fractions of a second
+//!
+//! Epoch:
+//!  - for dates in years 1968-2036, epoch starts from 1 Jan 1900 00:00:00
+//!  - for dates in years 2036-2104, epoch starts from 7 Feb 2036 06:28:16
+//!
+//! See RFC 5905 and RFC 2030.
 typedef uint64_t ntp_timestamp_t;
-
-//! Compares a and b if they close enough.
-bool ntp_equal_delta(ntp_timestamp_t a, ntp_timestamp_t b, ntp_timestamp_t delta);
 
 //! Convert Unix absolute time to NTP absolute time.
 //! @remarks
-//!  @p unix_time defines nanoseconds since Unix epoch (should be positive)
+//!  @p unix_time defines nanoseconds since Unix epoch (should belong to years 1968-2104).
 ntp_timestamp_t unix_2_ntp(core::nanoseconds_t unix_time);
 
 //! Convert NTP absolute time to Unix absolute time.

--- a/src/internal_modules/roc_packet/ntp.h
+++ b/src/internal_modules/roc_packet/ntp.h
@@ -28,6 +28,10 @@ namespace packet {
 //!  - for dates in years 2036-2104, epoch starts from 7 Feb 2036 06:28:16
 //!
 //! See RFC 5905 and RFC 2030.
+//!
+//! See also:
+//!  - https://tickelton.gitlab.io/articles/ntp-timestamps/
+//!  - https://www.eecis.udel.edu/~mills/y2k.html
 typedef uint64_t ntp_timestamp_t;
 
 //! Convert Unix absolute time to NTP absolute time.

--- a/src/tests/roc_packet/test_ntp.cpp
+++ b/src/tests/roc_packet/test_ntp.cpp
@@ -17,30 +17,131 @@ namespace packet {
 TEST_GROUP(ntp) {};
 
 TEST(ntp, ntp_2_unix) {
-    CHECK_EQUAL(0, ntp_2_unix((uint64_t)2208988800ul << 32));
-    CHECK_EQUAL((int64_t)1000 * 1000000000,
-                ntp_2_unix((uint64_t)(2208988800ul + 1000) << 32));
-    CHECK_EQUAL((int64_t)-1000 * 1000000000,
-                ntp_2_unix((uint64_t)(2208988800ul - 1000) << 32));
+    // unix epoch
+    CHECK_EQUAL(0, //
+                ntp_2_unix(uint64_t(2208988800ul) << 32));
+
+    // unix epoch + 1000 seconds
+    CHECK_EQUAL(1000 * core::Second, //
+                ntp_2_unix(uint64_t(2208988800ul + 1000) << 32));
+
+    // unix epoch - 1000 seconds
+    CHECK_EQUAL(-1000 * core::Second, //
+                ntp_2_unix(uint64_t(2208988800ul - 1000) << 32));
+
+    // era1
+    CHECK_EQUAL(2085978496ul * core::Second, //
+                ntp_2_unix(0));
+
+    // era1 + 1000 seconds
+    CHECK_EQUAL((2085978496ul + 1000) * core::Second, //
+                ntp_2_unix(uint64_t(1000) << 32));
+
+    // era1 - 1000 seconds
+    CHECK_EQUAL((2085978496ul - 1000) * core::Second, //
+                ntp_2_unix(uint64_t(2208988800ul + 2085978496ul - 1000) << 32));
 }
 
 TEST(ntp, unix_2_ntp) {
-    CHECK_EQUAL(((uint64_t)2208988800ul << 32), unix_2_ntp(0));
-    CHECK_EQUAL(((uint64_t)(2208988800ul + 1000) << 32),
-                unix_2_ntp((int64_t)1000 * 1000000000));
-    CHECK_EQUAL(((uint64_t)(2208988800ul - 1000) << 32),
-                unix_2_ntp((int64_t)-1000 * 1000000000));
+    // unix epoch
+    CHECK_EQUAL(uint64_t(2208988800ul) << 32, //
+                unix_2_ntp(0));
+
+    // unix epoch + 1000 seconds
+    CHECK_EQUAL(uint64_t(2208988800ul + 1000) << 32, //
+                unix_2_ntp(1000 * core::Second));
+
+    // unix epoch - 1000 seconds
+    CHECK_EQUAL(uint64_t(2208988800ul - 1000) << 32, //
+                unix_2_ntp(-1000 * core::Second));
+
+    // era1
+    CHECK_EQUAL(0, //
+                unix_2_ntp(2085978496ul * core::Second));
+
+    // era1 + 1000 seconds
+    CHECK_EQUAL(uint64_t(1000) << 32, //
+                unix_2_ntp((2085978496ul + 1000) * core::Second));
+
+    // era1 - 1000 seconds
+    CHECK_EQUAL(uint64_t(2208988800ul + 2085978496ul - 1000) << 32, //
+                unix_2_ntp((2085978496ul - 1000) * core::Second));
+}
+
+TEST(ntp, ntp_2_unix_2_ntp) {
+    // unix epoch
+    CHECK_EQUAL(uint64_t(2208988800ul) << 32, //
+                unix_2_ntp(ntp_2_unix(uint64_t(2208988800ul) << 32)));
+
+    // unix epoch + 1000 seconds
+    CHECK_EQUAL(uint64_t(2208988800ul + 1000) << 32, //
+                unix_2_ntp(ntp_2_unix(uint64_t(2208988800ul + 1000) << 32)));
+
+    // unix epoch - 1000 seconds
+    CHECK_EQUAL(uint64_t(2208988800ul - 1000) << 32, //
+                unix_2_ntp(ntp_2_unix(uint64_t(2208988800ul - 1000) << 32)));
+
+    // era1
+    CHECK_EQUAL(0, //
+                unix_2_ntp(ntp_2_unix(0)));
+
+    // era1 + 1000 seconds
+    CHECK_EQUAL(uint64_t(1000) << 32, //
+                unix_2_ntp(ntp_2_unix(uint64_t(1000) << 32)));
+
+    // era1 - 1000 seconds
+    CHECK_EQUAL(
+        uint64_t(2208988800ul + 2085978496ul - 1000) << 32, //
+        unix_2_ntp(ntp_2_unix(uint64_t(2208988800ul + 2085978496ul - 1000) << 32)));
+}
+
+TEST(ntp, unix_2_ntp_2_unix) {
+    // unix epoch
+    CHECK_EQUAL(0, //
+                ntp_2_unix(unix_2_ntp(0)));
+
+    // unix epoch + 1000 seconds
+    CHECK_EQUAL(1000 * core::Second, //
+                ntp_2_unix(unix_2_ntp(1000 * core::Second)));
+
+    // unix epoch - 1000 seconds
+    CHECK_EQUAL(-1000 * core::Second, //
+                ntp_2_unix(unix_2_ntp(-1000 * core::Second)));
+
+    // era1
+    CHECK_EQUAL(2085978496ul * core::Second, //
+                ntp_2_unix(unix_2_ntp(2085978496ul * core::Second)));
+
+    // era1 + 1000 seconds
+    CHECK_EQUAL((2085978496ul + 1000) * core::Second, //
+                ntp_2_unix(unix_2_ntp((2085978496ul + 1000) * core::Second)));
+
+    // era1 - 1000 seconds
+    CHECK_EQUAL((2085978496ul - 1000) * core::Second, //
+                ntp_2_unix(unix_2_ntp((2085978496ul - 1000) * core::Second)));
 }
 
 TEST(ntp, ntp_2_nanoseconds) {
+    // 0ns
     CHECK_EQUAL(0, ntp_2_nanoseconds(0));
+
+    // 1ns
+    CHECK_EQUAL(0, ntp_2_nanoseconds(1));
+
+    // 1500ms
     CHECK_EQUAL(1500 * core::Millisecond,
                 ntp_2_nanoseconds(((uint64_t)1 << 31) + ((uint64_t)1 << 32)));
 }
 
 TEST(ntp, nanoseconds_2_ntp) {
+    // 0ns
+    CHECK_EQUAL(0, nanoseconds_2_ntp(0));
+
+    // 1ns
     CHECK_EQUAL(ntp_timestamp_t(double(1e-9) * double((uint64_t)1 << 32)),
                 nanoseconds_2_ntp(1));
+
+    // 1500ms
     CHECK_EQUAL(((uint64_t)1 << 31) + ((uint64_t)1 << 32),
                 nanoseconds_2_ntp(1500 * core::Millisecond));
 }


### PR DESCRIPTION
Fixes #546.

unix_2_ntp() and ntp_2_unix() are updated according to RFC 2030.

ntp_equal_delta() is removed because it was never used and proper implementation is not trivial.