### PR TITLE
Extracted non-templated code out of RefCounted

### DIFF
--- a/src/internal_modules/roc_core/ref_counted.h
+++ b/src/internal_modules/roc_core/ref_counted.h
@@ -16,6 +16,7 @@
 #include "roc_core/atomic.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/panic.h"
+#include "roc_core/ref_counted_impl.h"
 
 namespace roc {
 namespace core {

--- a/src/internal_modules/roc_core/ref_counted.h
+++ b/src/internal_modules/roc_core/ref_counted.h
@@ -25,7 +25,7 @@ namespace core {
 //! reaches zero, the object is automatically destroyed.
 //!
 //! @tparam T defines the derived class.
-//! @tparam AllocationPolicy defies destroy policy.
+//! @tparam AllocationPolicy defines destroy policy.
 //!
 //! When reference counter becomes zero, AllocationPolicy::destroy() is invoked
 //! by RefCounted to destroy itself.

--- a/src/internal_modules/roc_core/ref_counted.h
+++ b/src/internal_modules/roc_core/ref_counted.h
@@ -13,9 +13,7 @@
 #define ROC_CORE_REF_COUNTED_H_
 
 #include "roc_core/allocation_policy.h"
-#include "roc_core/atomic.h"
 #include "roc_core/noncopyable.h"
-#include "roc_core/panic.h"
 #include "roc_core/ref_counted_impl.h"
 
 namespace roc {
@@ -43,79 +41,38 @@ class RefCounted : public NonCopyable<RefCounted<T, AllocationPolicy> >,
 public:
     //! Initialize.
     RefCounted()
-        : AllocationPolicy()
-        , counter_(0) {
+        : AllocationPolicy() {
     }
 
     //! Initialize.
     explicit RefCounted(const AllocationPolicy& policy)
-        : AllocationPolicy(policy)
-        , counter_(0) {
-    }
-
-    ~RefCounted() {
-        if (!counter_.compare_exchange(0, -1)) {
-            roc_panic(
-                "ref counter:"
-                " attempt to destroy object that is in use, destroyed, or corrupted:"
-                " counter=%d",
-                (int)counter_);
-        }
+        : AllocationPolicy(policy) {
     }
 
     //! Get reference counter.
     int getref() const {
-        const int current_counter = counter_;
-
-        if (current_counter < 0 || current_counter > MaxCounter) {
-            roc_panic("ref counter:"
-                      " attempt to access destroyed or currupted object:"
-                      " counter=%d",
-                      (int)current_counter);
-        }
-
-        return current_counter;
+        return impl_.getref();
     }
 
     //! Increment reference counter.
     void incref() const {
-        const int previous_counter = counter_++;
-
-        if (previous_counter < 0 || previous_counter > MaxCounter) {
-            roc_panic("ref counter:"
-                      " attempt to access destroyed or currupted object"
-                      " counter=%d",
-                      (int)previous_counter);
-        }
+        impl_.incref();
     }
 
     //! Decrement reference counter.
     //! @remarks
     //!  Destroys itself if reference counter becomes zero.
     void decref() const {
-        const int previous_counter = counter_--;
+        const int current_counter = impl_.decref();
 
-        if (previous_counter < 0 || previous_counter > MaxCounter) {
-            roc_panic("ref counter:"
-                      " attempt to access destroyed or currupted object"
-                      " counter=%d",
-                      (int)previous_counter);
-        }
-
-        if (previous_counter == 0) {
-            roc_panic("ref counter: unpaired incref/decref");
-        }
-
-        if (previous_counter == 1) {
+        if (current_counter == 0) {
             const_cast<RefCounted&>(*this).destroy(
                 static_cast<T&>(const_cast<RefCounted&>(*this)));
         }
     }
 
 private:
-    enum { MaxCounter = 100000 };
-
-    mutable Atomic<int> counter_;
+    RefCountedImpl impl_;
 };
 
 } // namespace core

--- a/src/internal_modules/roc_core/ref_counted_impl.cpp
+++ b/src/internal_modules/roc_core/ref_counted_impl.cpp
@@ -6,9 +6,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-//! @file roc_core/ref_counted_impl.cpp
-//! @brief Implementation class for object with reference counter.
-
 #include "roc_core/ref_counted_impl.h"
 #include "roc_core/panic.h"
 
@@ -33,7 +30,7 @@ int RefCountedImpl::getref() const {
 
     if (current_counter < 0 || current_counter > MaxCounter) {
         roc_panic("ref counter:"
-                  " attempt to access destroyed or currupted object:"
+                  " attempt to access destroyed or corrupted object:"
                   " counter=%d",
                   (int)current_counter);
     }
@@ -46,7 +43,7 @@ int RefCountedImpl::incref() const {
 
     if (current_counter < 0 || current_counter > MaxCounter) {
         roc_panic("ref counter:"
-                  " attempt to access destroyed or currupted object"
+                  " attempt to access destroyed or corrupted object"
                   " counter=%d",
                   (int)current_counter);
     }
@@ -59,7 +56,7 @@ int RefCountedImpl::decref() const {
 
     if (current_counter < 0 || current_counter > MaxCounter) {
         roc_panic("ref counter:"
-                  " attempt to access destroyed or currupted object"
+                  " attempt to access destroyed or corrupted object"
                   " counter=%d",
                   (int)current_counter);
     }

--- a/src/internal_modules/roc_core/ref_counted_impl.cpp
+++ b/src/internal_modules/roc_core/ref_counted_impl.cpp
@@ -1,0 +1,3 @@
+//
+// Created by nolan on 01/10/23.
+//

--- a/src/internal_modules/roc_core/ref_counted_impl.cpp
+++ b/src/internal_modules/roc_core/ref_counted_impl.cpp
@@ -1,3 +1,70 @@
-//
-// Created by nolan on 01/10/23.
-//
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_core/ref_counted_impl.cpp
+//! @brief Implementation class for object with reference counter.
+
+#include "roc_core/ref_counted_impl.h"
+#include "roc_core/panic.h"
+
+namespace roc {
+namespace core {
+
+RefCountedImpl::RefCountedImpl()
+    : counter_(0) {
+}
+
+RefCountedImpl::~RefCountedImpl() {
+    if (!counter_.compare_exchange(0, -1)) {
+        roc_panic("ref counter:"
+                  " attempt to destroy object that is in use, destroyed, or corrupted:"
+                  " counter=%d",
+                  (int)counter_);
+    }
+}
+
+int RefCountedImpl::getref() const {
+    const int current_counter = counter_;
+
+    if (current_counter < 0 || current_counter > MaxCounter) {
+        roc_panic("ref counter:"
+                  " attempt to access destroyed or currupted object:"
+                  " counter=%d",
+                  (int)current_counter);
+    }
+
+    return current_counter;
+}
+
+int RefCountedImpl::incref() const {
+    const int current_counter = ++counter_;
+
+    if (current_counter < 0 || current_counter > MaxCounter) {
+        roc_panic("ref counter:"
+                  " attempt to access destroyed or currupted object"
+                  " counter=%d",
+                  (int)current_counter);
+    }
+
+    return current_counter;
+}
+
+int RefCountedImpl::decref() const {
+    const int current_counter = --counter_;
+
+    if (current_counter < 0 || current_counter > MaxCounter) {
+        roc_panic("ref counter:"
+                  " attempt to access destroyed or currupted object"
+                  " counter=%d",
+                  (int)current_counter);
+    }
+    return current_counter;
+}
+
+} // namespace core
+} // namespace roc

--- a/src/internal_modules/roc_core/ref_counted_impl.h
+++ b/src/internal_modules/roc_core/ref_counted_impl.h
@@ -7,7 +7,7 @@
  */
 
 //! @file roc_core/ref_counted_impl.h
-//! @brief Implementation class for object with reference counter.
+//! @brief Implementation class for reference counter.
 
 #ifndef ROC_CORE_REF_COUNTED_IMPL_H_
 #define ROC_CORE_REF_COUNTED_IMPL_H_
@@ -17,6 +17,9 @@
 namespace roc {
 namespace core {
 
+//! Implementation class for reference counter.
+//!
+//! Allows to increment and decrement reference counter.
 class RefCountedImpl {
 public:
     //! Initialize.
@@ -28,11 +31,11 @@ public:
     int getref() const;
 
     //! Increment reference counter.
-    //! @returns counter value after incrementing.
+    //! @returns reference counter value after incrementing.
     int incref() const;
 
     //! Decrement reference counter.
-    //! @returns counter value after decrementing.
+    //! @returns reference counter value after decrementing.
     int decref() const;
 
 private:

--- a/src/internal_modules/roc_core/ref_counted_impl.h
+++ b/src/internal_modules/roc_core/ref_counted_impl.h
@@ -1,0 +1,27 @@
+/*
+* Copyright (c) 2023 Roc Streaming authors
+*
+* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+//! @file roc_core/ref_counted_impl.h
+//! @brief Implementation class for object with reference counter.
+
+#ifndef ROC_CORE_REF_COUNTED_IMPL_H_
+#define ROC_CORE_REF_COUNTED_IMPL_H_
+
+
+namespace roc {
+namespace core {
+
+class RefCountedImpl
+{
+
+};
+
+} // namespace core
+} // namespace roc
+
+#endif // ROC_CORE_REF_COUNTED_IMPL_H_

--- a/src/internal_modules/roc_core/ref_counted_impl.h
+++ b/src/internal_modules/roc_core/ref_counted_impl.h
@@ -1,10 +1,10 @@
 /*
-* Copyright (c) 2023 Roc Streaming authors
-*
-* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/.
-*/
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 //! @file roc_core/ref_counted_impl.h
 //! @brief Implementation class for object with reference counter.
@@ -12,13 +12,33 @@
 #ifndef ROC_CORE_REF_COUNTED_IMPL_H_
 #define ROC_CORE_REF_COUNTED_IMPL_H_
 
+#include "roc_core/atomic.h"
 
 namespace roc {
 namespace core {
 
-class RefCountedImpl
-{
+class RefCountedImpl {
+public:
+    //! Initialize.
+    RefCountedImpl();
 
+    ~RefCountedImpl();
+
+    //! Get reference counter.
+    int getref() const;
+
+    //! Increment reference counter.
+    //! @returns counter value after incrementing.
+    int incref() const;
+
+    //! Decrement reference counter.
+    //! @returns counter value after decrementing.
+    int decref() const;
+
+private:
+    enum { MaxCounter = 100000 };
+
+    mutable Atomic<int> counter_;
 };
 
 } // namespace core


### PR DESCRIPTION
# Why

For https://github.com/roc-streaming/roc-toolkit/issues/581

# What

* Created ref_counted_impl.(h|cpp) files.
* In RefCountedImpl, returned current_counter values from incref()/decref() after incrementing/decrementing.
  * Compared return value from decref against 0 to destroy itself.

# Testing

* Ensured tests are passing.