### PR TITLE
Extracted MpscQueueImpl class from MpscQueue

### DIFF
--- a/src/internal_modules/roc_core/mpsc_queue.h
+++ b/src/internal_modules/roc_core/mpsc_queue.h
@@ -13,7 +13,7 @@
 #define ROC_CORE_MPSC_QUEUE_H_
 
 #include "roc_core/atomic_ops.h"
-#include "roc_core/cpu_instructions.h"
+#include "roc_core/mpsc_queue_impl.h"
 #include "roc_core/mpsc_queue_node.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/ownership_policy.h"
@@ -44,11 +44,6 @@ public:
     //!  either raw or smart pointer depending on the ownership policy.
     typedef typename OwnershipPolicy<T>::Pointer Pointer;
 
-    MpscQueue()
-        : tail_(&stub_)
-        , head_(&stub_) {
-    }
-
     ~MpscQueue() {
         // release ownership of all objects
         while (pop_front_exclusive()) {
@@ -77,7 +72,7 @@ public:
 
         change_owner_(node, NULL, this);
 
-        push_node_(node);
+        impl_.push_back(node);
     }
 
     //! Try to remove object from the beginning of the queue (non-blocking version).
@@ -92,7 +87,7 @@ public:
     //!  - This operation is both lock-free and wait-free on all architectures, i.e. it
     //!    never waits for sleeping threads and never spins indefinitely.
     Pointer try_pop_front_exclusive() {
-        MpscQueueNode::MpscQueueData* node = pop_node_<false>();
+        MpscQueueNode::MpscQueueData* node = impl_.pop_front<false>();
         if (!node) {
             return NULL;
         }
@@ -117,7 +112,7 @@ public:
     //!  - On the "fast-path", however, this operation does not wait for any
     //!    threads and just performs a few atomic reads and writes.
     Pointer pop_front_exclusive() {
-        MpscQueueNode::MpscQueueData* node = pop_node_<true>();
+        MpscQueueNode::MpscQueueData* node = impl_.pop_front<true>();
         if (!node) {
             return NULL;
         }
@@ -141,101 +136,7 @@ private:
         }
     }
 
-    void push_node_(MpscQueueData* node) {
-        AtomicOps::store_relaxed(node->next, (MpscQueueData*)NULL);
-
-        MpscQueueData* prev = AtomicOps::exchange_seq_cst(tail_, node);
-
-        AtomicOps::store_release(prev->next, node);
-    }
-
-    template <bool CanSpin> MpscQueueData* pop_node_() {
-        MpscQueueData* head = AtomicOps::load_relaxed(head_);
-        MpscQueueData* next = AtomicOps::load_acquire(head->next);
-
-        if (head == &stub_) {
-            if (!next) {
-                if (AtomicOps::load_seq_cst(tail_) == head) {
-                    // queue is empty
-                    return NULL;
-                } else {
-                    // queue is not empty, so head->next == NULL means that
-                    // a push_node_() call is in progress
-                    if (!(next = (CanSpin ? wait_next_(head) : try_wait_next_(head)))) {
-                        // this may happen only if CanSpin is false
-                        return NULL;
-                    }
-                }
-            }
-            // remove stub from the beginning of the list
-            AtomicOps::store_relaxed(head_, next);
-            head = next;
-            next = AtomicOps::load_acquire(next->next);
-        }
-
-        if (!next) {
-            // head is not stub and head->next == NULL
-
-            if (AtomicOps::load_seq_cst(tail_) == head) {
-                // queue is empty
-                // add stub to the end of the list to ensure that we always
-                // have head->next when removing head and head wont become NULL
-                push_node_(&stub_);
-            }
-
-            // if head->next == NULL here means that a push_node_() call is in progress
-            if (!(next = (CanSpin ? wait_next_(head) : try_wait_next_(head)))) {
-                // this may happen only if CanSpin is false
-                return NULL;
-            }
-        }
-
-        // move list head to the next node
-        AtomicOps::store_relaxed(head_, next);
-
-        return head;
-    }
-
-    // Wait until concurrent push_node_() completes and node->next becomes non-NULL.
-    // This version may block indefinetely.
-    // Usually it returns immediately. It can block only if the thread performing
-    // push_node_() was interrupted exactly after updating tail and before updating
-    // next, and is now sleeping. In this rare case, this method will wait until the
-    // push_node_() thread is resumed and completed.
-    MpscQueueData* wait_next_(MpscQueueData* node) {
-        if (MpscQueueData* next = try_wait_next_(node)) {
-            return next;
-        }
-        for (;;) {
-            if (MpscQueueData* next = AtomicOps::load_seq_cst(node->next)) {
-                return next;
-            }
-            cpu_relax();
-        }
-    }
-
-    // Wait until concurrent push_node_() completes and node->next becomes non-NULL.
-    // This version is non-blocking and gives up after a few re-tries.
-    // Usually it succeeds. It can fail only in the same rare case when
-    // wait_next_() blocks.
-    MpscQueueData* try_wait_next_(MpscQueueData* node) {
-        MpscQueueData* next;
-        if ((next = AtomicOps::load_acquire(node->next))) {
-            return next;
-        }
-        if ((next = AtomicOps::load_acquire(node->next))) {
-            return next;
-        }
-        if ((next = AtomicOps::load_acquire(node->next))) {
-            return next;
-        }
-        return NULL;
-    }
-
-    MpscQueueData* tail_;
-    MpscQueueData* head_;
-
-    MpscQueueData stub_;
+    MpscQueueImpl impl_;
 };
 
 } // namespace core

--- a/src/internal_modules/roc_core/mpsc_queue.h
+++ b/src/internal_modules/roc_core/mpsc_queue.h
@@ -120,8 +120,6 @@ public:
     }
 
 private:
-    typedef MpscQueueNode::MpscQueueData MpscQueueData;
-
     MpscQueueImpl impl_;
 };
 

--- a/src/internal_modules/roc_core/mpsc_queue_impl.cpp
+++ b/src/internal_modules/roc_core/mpsc_queue_impl.cpp
@@ -18,6 +18,12 @@ MpscQueueImpl::MpscQueueImpl()
     , head_(&stub_) {
 }
 
+MpscQueueImpl::~MpscQueueImpl() {
+    if (head_ != &stub_) {
+        roc_panic("mpsc_queue_impl: queue isn't empty on destruct");
+    }
+}
+
 void MpscQueueImpl::push_back(MpscQueueData* node) {
     push_node_(node);
 }

--- a/src/internal_modules/roc_core/mpsc_queue_impl.cpp
+++ b/src/internal_modules/roc_core/mpsc_queue_impl.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_core/mpsc_queue_impl.h"
+#include "roc_core/atomic_ops.h"
+#include "roc_core/cpu_instructions.h"
+
+namespace roc {
+namespace core {
+
+MpscQueueImpl::MpscQueueImpl()
+    : tail_(&stub_)
+    , head_(&stub_) {
+}
+
+void MpscQueueImpl::push_back(MpscQueueData* node) {
+    push_node_(node);
+}
+
+void MpscQueueImpl::push_node_(MpscQueueData* node) {
+    AtomicOps::store_relaxed(node->next, (MpscQueueData*)NULL);
+
+    MpscQueueData* prev = AtomicOps::exchange_seq_cst(tail_, node);
+
+    AtomicOps::store_release(prev->next, node);
+}
+
+MpscQueueImpl::MpscQueueData* MpscQueueImpl::pop_node_(bool can_spin) {
+    MpscQueueData* head = AtomicOps::load_relaxed(head_);
+    MpscQueueData* next = AtomicOps::load_acquire(head->next);
+
+    if (head == &stub_) {
+        if (!next) {
+            if (AtomicOps::load_seq_cst(tail_) == head) {
+                // queue is empty
+                return NULL;
+            } else {
+                // queue is not empty, so head->next == NULL means that
+                // a push_node_() call is in progress
+                if (!(next = (can_spin ? wait_next_(head) : try_wait_next_(head)))) {
+                    // this may happen only if CanSpin is false
+                    return NULL;
+                }
+            }
+        }
+        // remove stub from the beginning of the list
+        AtomicOps::store_relaxed(head_, next);
+        head = next;
+        next = AtomicOps::load_acquire(next->next);
+    }
+
+    if (!next) {
+        // head is not stub and head->next == NULL
+
+        if (AtomicOps::load_seq_cst(tail_) == head) {
+            // queue is empty
+            // add stub to the end of the list to ensure that we always
+            // have head->next when removing head and head wont become NULL
+            push_node_(&stub_);
+        }
+
+        // if head->next == NULL here means that a push_node_() call is in progress
+        if (!(next = (can_spin ? wait_next_(head) : try_wait_next_(head)))) {
+            // this may happen only if CanSpin is false
+            return NULL;
+        }
+    }
+
+    // move list head to the next node
+    AtomicOps::store_relaxed(head_, next);
+
+    return head;
+}
+
+MpscQueueImpl::MpscQueueData* MpscQueueImpl::wait_next_(MpscQueueData* node) {
+    if (MpscQueueData* next = try_wait_next_(node)) {
+        return next;
+    }
+    for (;;) {
+        if (MpscQueueData* next = AtomicOps::load_seq_cst(node->next)) {
+            return next;
+        }
+        cpu_relax();
+    }
+}
+
+MpscQueueImpl::MpscQueueData* MpscQueueImpl::try_wait_next_(MpscQueueData* node) {
+    MpscQueueData* next;
+    if ((next = AtomicOps::load_acquire(node->next))) {
+        return next;
+    }
+    if ((next = AtomicOps::load_acquire(node->next))) {
+        return next;
+    }
+    if ((next = AtomicOps::load_acquire(node->next))) {
+        return next;
+    }
+    return NULL;
+}
+
+} // namespace core
+} // namespace roc

--- a/src/internal_modules/roc_core/mpsc_queue_impl.cpp
+++ b/src/internal_modules/roc_core/mpsc_queue_impl.cpp
@@ -20,7 +20,7 @@ MpscQueueImpl::MpscQueueImpl()
 
 MpscQueueImpl::~MpscQueueImpl() {
     if (head_ != &stub_) {
-        roc_panic("mpsc_queue: queue isn't empty on destruct");
+        roc_panic("mpsc queue: queue isn't empty on destruct");
     }
 }
 
@@ -56,7 +56,7 @@ MpscQueueImpl::MpscQueueData* MpscQueueImpl::pop_node_(bool can_spin) {
                 // queue is not empty, so head->next == NULL means that
                 // a push_node_() call is in progress
                 if (!(next = (can_spin ? wait_next_(head) : try_wait_next_(head)))) {
-                    // this may happen only if CanSpin is false
+                    // this may happen only if can_spin is false
                     return NULL;
                 }
             }
@@ -79,7 +79,7 @@ MpscQueueImpl::MpscQueueData* MpscQueueImpl::pop_node_(bool can_spin) {
 
         // if head->next == NULL here means that a push_node_() call is in progress
         if (!(next = (can_spin ? wait_next_(head) : try_wait_next_(head)))) {
-            // this may happen only if CanSpin is false
+            // this may happen only if can_spin is false
             return NULL;
         }
     }

--- a/src/internal_modules/roc_core/mpsc_queue_impl.h
+++ b/src/internal_modules/roc_core/mpsc_queue_impl.h
@@ -21,6 +21,8 @@ class MpscQueueImpl {
 public:
     MpscQueueImpl();
 
+    ~MpscQueueImpl();
+
     void push_back(MpscQueueNode::MpscQueueData* node);
 
     template <bool CanSpin> MpscQueueNode::MpscQueueData* pop_front() {

--- a/src/internal_modules/roc_core/mpsc_queue_impl.h
+++ b/src/internal_modules/roc_core/mpsc_queue_impl.h
@@ -19,15 +19,18 @@ namespace core {
 
 //! Multi-producer single-consumer queue internal implementation class.
 //!
-//! Provides only push/pop functionality. Ownership is left up to the main MpscQueue class.
+//! Provides only push/pop functionality. Ownership is left up to the main MpscQueue
+//! class.
 class MpscQueueImpl {
 public:
     MpscQueueImpl();
 
     ~MpscQueueImpl();
 
+    //! Add object to the end of the queue.
     void push_back(MpscQueueNode::MpscQueueData* node);
 
+    //! Remove object from the beginning of the queue.
     template <bool CanSpin> MpscQueueNode::MpscQueueData* pop_front() {
         return pop_node_(CanSpin);
     }

--- a/src/internal_modules/roc_core/mpsc_queue_impl.h
+++ b/src/internal_modules/roc_core/mpsc_queue_impl.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_core/mpsc_queue_impl.h
+//! @brief Multi-producer single-consumer queue internal implementation.
+
+#ifndef ROC_CORE_MPSC_QUEUE_IMPL_H_
+#define ROC_CORE_MPSC_QUEUE_IMPL_H_
+
+#include "roc_core/mpsc_queue_node.h"
+
+namespace roc {
+namespace core {
+
+class MpscQueueImpl {
+public:
+    MpscQueueImpl();
+
+    void push_back(MpscQueueNode::MpscQueueData* node);
+
+    template <bool CanSpin> MpscQueueNode::MpscQueueData* pop_front() {
+        return pop_node_(CanSpin);
+    }
+
+private:
+    typedef MpscQueueNode::MpscQueueData MpscQueueData;
+
+    void push_node_(MpscQueueData* node);
+
+    MpscQueueData* pop_node_(bool can_spin);
+
+    // Wait until concurrent push_node_() completes and node->next becomes non-NULL.
+    // This version may block indefinetely.
+    // Usually it returns immediately. It can block only if the thread performing
+    // push_node_() was interrupted exactly after updating tail and before updating
+    // next, and is now sleeping. In this rare case, this method will wait until the
+    // push_node_() thread is resumed and completed.
+    MpscQueueData* wait_next_(MpscQueueData* node);
+
+    // Wait until concurrent push_node_() completes and node->next becomes non-NULL.
+    // This version is non-blocking and gives up after a few re-tries.
+    // Usually it succeeds. It can fail only in the same rare case when
+    // wait_next_() blocks.
+    MpscQueueData* try_wait_next_(MpscQueueData* node);
+
+    MpscQueueData* tail_;
+    MpscQueueData* head_;
+
+    MpscQueueData stub_;
+};
+
+} // namespace core
+} // namespace roc
+
+#endif // ROC_CORE_MPSC_QUEUE_IMPL_H_

--- a/src/internal_modules/roc_core/mpsc_queue_impl.h
+++ b/src/internal_modules/roc_core/mpsc_queue_impl.h
@@ -37,11 +37,9 @@ private:
     typedef MpscQueueNode::MpscQueueData MpscQueueData;
 
     void push_node_(MpscQueueData* node);
-
     MpscQueueData* pop_node_(bool can_spin);
 
     MpscQueueData* wait_next_(MpscQueueData* node);
-
     MpscQueueData* try_wait_next_(MpscQueueData* node);
 
     void change_owner_(MpscQueueData* node, void* from, void* to);

--- a/src/internal_modules/roc_core/mpsc_queue_impl.h
+++ b/src/internal_modules/roc_core/mpsc_queue_impl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Roc Streaming authors
+ * Copyright (c) 2020 Roc Streaming authors
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -31,9 +31,7 @@ public:
     void push_back(MpscQueueNode::MpscQueueData* node);
 
     //! Remove object from the beginning of the queue.
-    template <bool CanSpin> MpscQueueNode::MpscQueueData* pop_front() {
-        return pop_node_(CanSpin);
-    }
+    MpscQueueNode::MpscQueueData* pop_front(bool can_spin);
 
 private:
     typedef MpscQueueNode::MpscQueueData MpscQueueData;
@@ -42,19 +40,11 @@ private:
 
     MpscQueueData* pop_node_(bool can_spin);
 
-    // Wait until concurrent push_node_() completes and node->next becomes non-NULL.
-    // This version may block indefinetely.
-    // Usually it returns immediately. It can block only if the thread performing
-    // push_node_() was interrupted exactly after updating tail and before updating
-    // next, and is now sleeping. In this rare case, this method will wait until the
-    // push_node_() thread is resumed and completed.
     MpscQueueData* wait_next_(MpscQueueData* node);
 
-    // Wait until concurrent push_node_() completes and node->next becomes non-NULL.
-    // This version is non-blocking and gives up after a few re-tries.
-    // Usually it succeeds. It can fail only in the same rare case when
-    // wait_next_() blocks.
     MpscQueueData* try_wait_next_(MpscQueueData* node);
+
+    void change_owner_(MpscQueueData* node, void* from, void* to);
 
     MpscQueueData* tail_;
     MpscQueueData* head_;

--- a/src/internal_modules/roc_core/mpsc_queue_impl.h
+++ b/src/internal_modules/roc_core/mpsc_queue_impl.h
@@ -17,6 +17,9 @@
 namespace roc {
 namespace core {
 
+//! Multi-producer single-consumer queue internal implementation class.
+//!
+//! Provides only push/pop functionality. Ownership is left up to the main MpscQueue class.
 class MpscQueueImpl {
 public:
     MpscQueueImpl();


### PR DESCRIPTION
# Why

For https://github.com/roc-streaming/roc-toolkit/issues/580

# What

* Created separate mpsc_queue_impl.(h|cpp) files, with code from mpsc_queue.h
  * Kept ownership bits in MpscQueue.

# Testing

* Ensured tests ran.