### PR TITLE
Slab pool ownership guard

### DIFF
--- a/src/internal_modules/roc_core/align_ops.h
+++ b/src/internal_modules/roc_core/align_ops.h
@@ -24,6 +24,16 @@ union AlignMax {
     void (*p)(); //!< 4-, 8- or 16-byte function pointer.
 };
 
+//! Size of AlignMax.
+enum { AlignMaxSize = sizeof(AlignMax) };
+
+//! Size aligned to AlignMax. For compile time.
+template <size_t Size> struct MaxAlignedSize {
+    enum {
+        value = ((Size + AlignMaxSize - 1) / AlignMaxSize) * AlignMaxSize,
+    };
+};
+
 //! Alignment operations.
 class AlignOps {
 public:

--- a/src/internal_modules/roc_core/align_ops.h
+++ b/src/internal_modules/roc_core/align_ops.h
@@ -24,16 +24,6 @@ union AlignMax {
     void (*p)(); //!< 4-, 8- or 16-byte function pointer.
 };
 
-//! Size of AlignMax.
-enum { AlignMaxSize = sizeof(AlignMax) };
-
-//! Size aligned to AlignMax. For compile time.
-template <size_t Size> struct MaxAlignedSize {
-    enum {
-        value = ((Size + AlignMaxSize - 1) / AlignMaxSize) * AlignMaxSize,
-    };
-};
-
 //! Alignment operations.
 class AlignOps {
 public:

--- a/src/internal_modules/roc_core/pool.h
+++ b/src/internal_modules/roc_core/pool.h
@@ -116,7 +116,7 @@ public:
     }
 
 private:
-    AlignedStorage<EmbeddedCapacity * PoolImpl::CalculateSlotSize<sizeof(T)>::value>
+    AlignedStorage<EmbeddedCapacity * PoolImpl::SlotSize<sizeof(T)>::value>
         embedded_data_;
     PoolImpl impl_;
 };

--- a/src/internal_modules/roc_core/pool.h
+++ b/src/internal_modules/roc_core/pool.h
@@ -115,8 +115,12 @@ public:
     }
 
 private:
-    AlignedStorage<EmbeddedCapacity * PoolImpl::SlotSize<sizeof(T)>::value>
-        embedded_data_;
+    enum {
+        SlotSize = (sizeof(PoolImpl::SlotHeader) + sizeof(PoolImpl::SlotCanary)
+                    + sizeof(T) + sizeof(PoolImpl::SlotCanary) + sizeof(AlignMax) - 1)
+            / sizeof(AlignMax) * sizeof(AlignMax)
+    };
+    AlignedStorage<EmbeddedCapacity * SlotSize> embedded_data_;
     PoolImpl impl_;
 };
 

--- a/src/internal_modules/roc_core/pool.h
+++ b/src/internal_modules/roc_core/pool.h
@@ -109,8 +109,7 @@ public:
     }
 
 private:
-    AlignedStorage<EmbeddedCapacity*(sizeof(T) + PoolImpl::CanarySize
-                                     + PoolImpl::CanarySize)>
+    AlignedStorage<EmbeddedCapacity * PoolImpl::CalculateSlotSize<sizeof(T)>::value>
         embedded_data_;
     PoolImpl impl_;
 };

--- a/src/internal_modules/roc_core/pool.h
+++ b/src/internal_modules/roc_core/pool.h
@@ -25,13 +25,12 @@ namespace core {
 
 //! Memory pool flags.
 enum PoolFlags {
-    PoolFlag_PanicOnOverflow = (1 << 0),         //!< Panic when buffer overflow detected.
-    PoolFlag_PanicOnInvalidOwnership = (1 << 1), //!< Panic when invalid ownership
-                                                 //!< detected.
+    //! Panic when buffer overflow and invalid ownership is detected.
+    PoolFlag_EnableGuards = (1 << 0),
 };
 
 //! Default memory pool flags.
-enum { DefaultPoolFlags = (PoolFlag_PanicOnOverflow | PoolFlag_PanicOnInvalidOwnership) };
+enum { DefaultPoolFlags = (PoolFlag_EnableGuards) };
 
 //! Memory pool.
 //!

--- a/src/internal_modules/roc_core/pool.h
+++ b/src/internal_modules/roc_core/pool.h
@@ -25,7 +25,7 @@ namespace core {
 
 //! Memory pool flags.
 enum PoolFlags {
-    //! Panic when buffer overflow and invalid ownership is detected.
+    //! Enable guards for buffer overflow, invalid ownership, etc.
     PoolFlag_EnableGuards = (1 << 0),
 };
 
@@ -105,13 +105,8 @@ public:
     }
 
     //! Get number of buffer overflows detected.
-    size_t num_buffer_overflows() const {
-        return impl_.num_buffer_overflows();
-    }
-
-    //! Get number of invalid ownerships detected.
-    size_t num_invalid_ownerships() const {
-        return impl_.num_invalid_ownerships();
+    size_t num_guard_failures() const {
+        return impl_.num_guard_failures();
     }
 
 private:

--- a/src/internal_modules/roc_core/pool.h
+++ b/src/internal_modules/roc_core/pool.h
@@ -25,11 +25,13 @@ namespace core {
 
 //! Memory pool flags.
 enum PoolFlags {
-    PoolFlag_PanicOnOverflow = (1 << 0), //!< Panic when buffer overflow detected.
+    PoolFlag_PanicOnOverflow = (1 << 0),         //!< Panic when buffer overflow detected.
+    PoolFlag_PanicOnInvalidOwnership = (1 << 1), //!< Panic when invalid ownership
+                                                 //!< detected.
 };
 
 //! Default memory pool flags.
-enum { DefaultPoolFlags = (PoolFlag_PanicOnOverflow) };
+enum { DefaultPoolFlags = (PoolFlag_PanicOnOverflow | PoolFlag_PanicOnInvalidOwnership) };
 
 //! Memory pool.
 //!
@@ -106,6 +108,11 @@ public:
     //! Get number of buffer overflows detected.
     size_t num_buffer_overflows() const {
         return impl_.num_buffer_overflows();
+    }
+
+    //! Get number of invalid ownerships detected.
+    size_t num_invalid_ownerships() const {
+        return impl_.num_invalid_ownerships();
     }
 
 private:

--- a/src/internal_modules/roc_core/pool_impl.cpp
+++ b/src/internal_modules/roc_core/pool_impl.cpp
@@ -159,7 +159,9 @@ PoolImpl::Slot* PoolImpl::take_slot_from_user_(void* memory) {
         }
     }
 
-    if (userSlot->owner != this) {
+    bool is_owner = userSlot->owner == this;
+
+    if (!is_owner) {
         num_invalid_ownerships_++;
         if ((flags_ & PoolFlag_PanicOnInvalidOwnership) != 0) {
             roc_panic("pool: invalid ownership detected: name=%s", name_);

--- a/src/internal_modules/roc_core/pool_impl.cpp
+++ b/src/internal_modules/roc_core/pool_impl.cpp
@@ -154,7 +154,7 @@ PoolImpl::Slot* PoolImpl::take_slot_from_user_(void* memory) {
 
     if (!canary_before_ok || !canary_after_ok) {
         num_buffer_overflows_++;
-        if ((flags_ & PoolFlag_PanicOnOverflow) != 0) {
+        if ((flags_ & PoolFlag_EnableGuards) != 0) {
             roc_panic("pool: buffer overflow detected: name=%s", name_);
         }
     }
@@ -163,7 +163,7 @@ PoolImpl::Slot* PoolImpl::take_slot_from_user_(void* memory) {
 
     if (!is_owner) {
         num_invalid_ownerships_++;
-        if ((flags_ & PoolFlag_PanicOnInvalidOwnership) != 0) {
+        if ((flags_ & PoolFlag_EnableGuards) != 0) {
             roc_panic("pool: invalid ownership detected: name=%s", name_);
         }
         return NULL;

--- a/src/internal_modules/roc_core/pool_impl.cpp
+++ b/src/internal_modules/roc_core/pool_impl.cpp
@@ -129,6 +129,8 @@ void* PoolImpl::give_slot_to_user_(Slot* slot) {
 
     UserSlot* userSlot = (UserSlot*)slot;
 
+    userSlot->owner = this;
+
     void* canary_before = &userSlot->canary_before;
     void* memory = userSlot->data;
     void* canary_after = (char*)userSlot->data + object_size_;
@@ -136,8 +138,6 @@ void* PoolImpl::give_slot_to_user_(Slot* slot) {
     MemoryOps::prepare_canary(canary_before, CanarySize);
     MemoryOps::poison_before_use(memory, object_size_);
     MemoryOps::prepare_canary(canary_after, object_size_padding_ + CanarySize);
-
-    userSlot->owner = this;
 
     return memory;
 }

--- a/src/internal_modules/roc_core/pool_impl.h
+++ b/src/internal_modules/roc_core/pool_impl.h
@@ -30,19 +30,31 @@ namespace core {
 //!
 //! @see Pool.
 class PoolImpl : public NonCopyable<> {
+private:
+    struct Slab : ListNode {};
+    struct Slot : ListNode {};
+
+    // Slot layout when supplying data to user.
+    struct UserSlot {
+        PoolImpl* owner;
+        AlignMax canary_before;
+        AlignMax data[];
+        // Another canary immediately after actual data. Any padding for data is
+        // considered part of canary.
+    };
+
 public:
     //! Size for canary guard.
     enum { CanarySize = sizeof(AlignMax) };
 
     //! Size of slot given object size.
     //! Used at compile time to calculate embedded storage in main Pool class.
-    template <size_t ObjectSize> struct CalculateSlotSize {
+    template <size_t ObjectSize> struct SlotSize {
     private:
         enum {
-            slot_size_ = MaxAlignedSize<sizeof(ListNode)>::value,
-            user_slot_size_ = MaxAlignedSize<sizeof(PoolImpl*)>::value
-                + PoolImpl::CanarySize + MaxAlignedSize<ObjectSize>::value
-                + PoolImpl::CanarySize,
+            slot_size_ = MaxAlignedSize<sizeof(Slot)>::value,
+            user_slot_size_ = MaxAlignedSize<sizeof(UserSlot)>::value
+                + MaxAlignedSize<ObjectSize>::value + PoolImpl::CanarySize,
         };
 
     public:
@@ -83,18 +95,6 @@ public:
     size_t num_invalid_ownerships() const;
 
 private:
-    struct Slab : ListNode {};
-    struct Slot : ListNode {};
-
-    // Slot layout when supplying data to user.
-    struct UserSlot {
-        PoolImpl* owner;
-        AlignMax canary_before;
-        AlignMax data[];
-        // Another canary immediately after data.
-        // Any padding for data is considered part of canary.
-    };
-
     void* give_slot_to_user_(Slot* slot);
     Slot* take_slot_from_user_(void* memory);
 

--- a/src/internal_modules/roc_core/pool_impl.h
+++ b/src/internal_modules/roc_core/pool_impl.h
@@ -33,10 +33,13 @@ class PoolImpl : public NonCopyable<> {
 public:
     //! Slot header.
     struct SlotHeader {
+        //! The pool that the slot belongs to.
         PoolImpl* owner;
+        //! Variable-length data surrounded by canary guard.
         AlignMax data[];
     };
-    //! Canary guard will surround variable data and includes any padding for data.
+
+    //! Canary guard which surrounds variable-length data.
     typedef AlignMax SlotCanary;
 
     //! Initialize.

--- a/src/internal_modules/roc_core/pool_impl.h
+++ b/src/internal_modules/roc_core/pool_impl.h
@@ -64,11 +64,8 @@ public:
     //! Return memory to pool.
     void deallocate(void* memory);
 
-    //! Get number of buffer overflows detected.
-    size_t num_buffer_overflows() const;
-
-    //! Get number of invalid ownerships detected.
-    size_t num_invalid_ownerships() const;
+    //! Get number of guard failures.
+    size_t num_guard_failures() const;
 
 private:
     struct Slab : ListNode {};
@@ -112,8 +109,7 @@ private:
     const size_t object_size_padding_;
 
     const size_t flags_;
-    size_t num_buffer_overflows_;
-    size_t num_invalid_ownerships_;
+    size_t num_guard_failures_;
 };
 
 } // namespace core

--- a/src/internal_modules/roc_core/pool_impl.h
+++ b/src/internal_modules/roc_core/pool_impl.h
@@ -71,8 +71,6 @@ public:
     size_t num_invalid_ownerships() const;
 
 private:
-    enum { CanarySize = sizeof(SlotCanary) };
-
     struct Slab : ListNode {};
     struct Slot : ListNode {};
 

--- a/src/internal_modules/roc_core/pool_impl.h
+++ b/src/internal_modules/roc_core/pool_impl.h
@@ -79,6 +79,9 @@ public:
     //! Get number of buffer overflows detected.
     size_t num_buffer_overflows() const;
 
+    //! Get number of invalid ownerships detected.
+    size_t num_invalid_ownerships() const;
+
 private:
     struct Slab : ListNode {};
     struct Slot : ListNode {};
@@ -131,6 +134,7 @@ private:
 
     const size_t flags_;
     size_t num_buffer_overflows_;
+    size_t num_invalid_ownerships_;
 };
 
 } // namespace core

--- a/src/tests/roc_core/test_pool.cpp
+++ b/src/tests/roc_core/test_pool.cpp
@@ -500,7 +500,7 @@ TEST(pool, guard_object) {
 TEST(pool, guard_object_violations) {
     TestArena arena;
     Pool<TestObject, 1> pool("test", arena, sizeof(TestObject), 0, 0,
-                             (DefaultPoolFlags & ~PoolFlag_PanicOnOverflow));
+                             (DefaultPoolFlags & ~PoolFlag_EnableGuards));
     void* pointers[2] = {};
 
     pointers[0] = pool.allocate();
@@ -529,7 +529,7 @@ TEST(pool, guard_object_violations) {
 TEST(pool, object_ownership_guard) {
     TestArena arena;
     Pool<TestObject, 1> pool0("test", arena, sizeof(TestObject), 0, 0,
-                              (DefaultPoolFlags & ~PoolFlag_PanicOnInvalidOwnership));
+                              (DefaultPoolFlags & ~PoolFlag_EnableGuards));
     Pool<TestObject, 1> pool1("test", arena);
 
     void* pointers[2] = {};

--- a/src/tests/roc_core/test_pool.cpp
+++ b/src/tests/roc_core/test_pool.cpp
@@ -515,7 +515,7 @@ TEST(pool, guard_object_violations) {
         *data = 0x00;
     }
     pool.deallocate(pointers[0]);
-    CHECK(pool.num_buffer_overflows() == 1);
+    CHECK(pool.num_guard_failures() == 1);
 
     {
         char* data = (char*)pointers[1];
@@ -523,7 +523,7 @@ TEST(pool, guard_object_violations) {
         *data = 0x00;
     }
     pool.deallocate(pointers[1]);
-    CHECK(pool.num_buffer_overflows() == 2);
+    CHECK(pool.num_guard_failures() == 2);
 }
 
 TEST(pool, object_ownership_guard) {
@@ -541,7 +541,7 @@ TEST(pool, object_ownership_guard) {
     CHECK(pointers[1]);
 
     pool0.deallocate(pointers[1]);
-    CHECK(pool0.num_invalid_ownerships() == 1);
+    CHECK(pool0.num_guard_failures() == 1);
 
     pool0.deallocate(pointers[0]);
     pool1.deallocate(pointers[1]);


### PR DESCRIPTION
# Why

For https://github.com/roc-streaming/roc-toolkit/issues/582

# What

* Chose to use a struct for the layout of the slot when supplying memory to user.
  * Owner is first member, then canary guard, then zero-length array data.
    * The actual data follows, then another canary guard.
* Added new flag.
* Updated logic to set/check owner.
* Some compile time enums/structs for sizeof AlignMax and aligning size based on that.
  * This is so that embedded storage size is easily calculated, with the size per slot in the impl class.

# Testing

* Added tests.