### PR TITLE
New "speexdec" resampler

### DIFF
--- a/src/internal_modules/roc_audio/decimation_resampler.cpp
+++ b/src/internal_modules/roc_audio/decimation_resampler.cpp
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_audio/decimation_resampler.h"
+#include "roc_audio/sample_spec_to_str.h"
+#include "roc_core/log.h"
+#include "roc_core/macro_helpers.h"
+#include "roc_core/panic.h"
+#include "roc_core/stddefs.h"
+#include "roc_packet/units.h"
+
+namespace roc {
+namespace audio {
+
+namespace {
+
+const core::nanoseconds_t LogReportInterval = 20 * core::Second;
+
+const size_t InputFrameSize = 16;
+
+} // namespace
+
+DecimationResampler::DecimationResampler(
+    const core::SharedPtr<IResampler>& inner_resampler,
+    core::IArena& arena,
+    core::BufferFactory<sample_t>& buffer_factory,
+    const audio::SampleSpec& in_spec,
+    const audio::SampleSpec& out_spec)
+    : IResampler(arena)
+    , inner_resampler_(inner_resampler)
+    , use_inner_resampler_(in_spec.sample_rate() != out_spec.sample_rate())
+    , input_spec_(in_spec)
+    , output_spec_(out_spec)
+    , multiplier_(1.0f)
+    , num_ch_(in_spec.num_channels())
+    , in_size_(0)
+    , in_pos_(0)
+    , out_acc_(0)
+    , total_count_(0)
+    , decim_count_(0)
+    , report_limiter_(LogReportInterval)
+    , valid_(false) {
+    if (!in_spec.is_valid() || !out_spec.is_valid()) {
+        roc_log(LogError,
+                "decimation resampler: invalid sample spec:"
+                " in_spec=%s out_spec=%s",
+                sample_spec_to_str(in_spec).c_str(),
+                sample_spec_to_str(out_spec).c_str());
+        return;
+    }
+
+    if (in_spec.channel_set() != out_spec.channel_set()) {
+        roc_log(LogError,
+                "decimation resampler: input and output channel sets should be equal:"
+                " in_spec=%s out_spec=%s",
+                sample_spec_to_str(in_spec).c_str(),
+                sample_spec_to_str(out_spec).c_str());
+        return;
+    }
+
+    if (buffer_factory.buffer_size() < InputFrameSize * num_ch_) {
+        roc_log(LogError, "decimation resampler: can't allocate temporary buffer");
+        return;
+    }
+
+    in_buf_ = buffer_factory.new_buffer();
+    if (!in_buf_) {
+        roc_log(LogError, "decimation resampler: can't allocate temporary buffer");
+        return;
+    }
+    in_buf_.reslice(0, InputFrameSize * num_ch_);
+
+    last_buf_ = buffer_factory.new_buffer();
+    if (!last_buf_) {
+        roc_log(LogError, "decimation resampler: can't allocate temporary buffer");
+        return;
+    }
+    last_buf_.reslice(0, num_ch_);
+
+    memset(last_buf_.data(), 0, last_buf_.size() * sizeof(sample_t));
+
+    roc_log(LogDebug,
+            "decimation resampler: initializing: "
+            " frame_size=%lu num_ch=%lu use_inner_resampler=%d",
+            (unsigned long)in_size_, (unsigned long)num_ch_, (int)use_inner_resampler_);
+
+    valid_ = true;
+}
+
+DecimationResampler::~DecimationResampler() {
+}
+
+bool DecimationResampler::is_valid() const {
+    return valid_;
+}
+
+bool DecimationResampler::set_scaling(size_t input_rate,
+                                      size_t output_rate,
+                                      float multiplier) {
+    roc_panic_if_not(is_valid());
+
+    if (input_rate == 0 || output_rate == 0
+        || multiplier <= 0
+        // no more than num_ch insertions/removals per input frame,
+        // because we insert or remove only one sample per time
+        || std::abs(in_buf_.size() / multiplier - in_buf_.size()) > num_ch_) {
+        roc_log(LogError,
+                "decimation resampler:"
+                " scaling out of range: in_rate=%lu out_rate=%lu mult=%e",
+                (unsigned long)input_rate, (unsigned long)output_rate,
+                (double)multiplier);
+        return false;
+    }
+
+    use_inner_resampler_ = (input_rate != output_rate);
+
+    if (use_inner_resampler_) {
+        // always pass 1.0 instead of multiplier to inner resampler
+        if (!inner_resampler_->set_scaling(input_rate, output_rate, 1.0f)) {
+            return false;
+        }
+    }
+
+    input_spec_.set_sample_rate(input_rate);
+    output_spec_.set_sample_rate(output_rate);
+
+    multiplier_ = multiplier;
+
+    return true;
+}
+
+const core::Slice<sample_t>& DecimationResampler::begin_push_input() {
+    roc_panic_if_not(is_valid());
+
+    if (use_inner_resampler_) {
+        // return buffer of inner resampler
+        return inner_resampler_->begin_push_input();
+    }
+
+    // return our buffer
+    return in_buf_;
+}
+
+void DecimationResampler::end_push_input() {
+    roc_panic_if_not(is_valid());
+
+    if (use_inner_resampler_) {
+        // start reading from inner resampler
+        inner_resampler_->end_push_input();
+        return;
+    }
+
+    // start reading from our buffer
+    in_size_ = in_buf_.size();
+    in_pos_ = 0;
+    out_acc_ += in_size_ / multiplier_;
+}
+
+size_t DecimationResampler::pop_output(sample_t* out_data, size_t out_size) {
+    roc_panic_if_not(is_valid());
+
+    size_t out_pos = 0;
+
+    while (out_pos < out_size) {
+        // self-check
+        roc_panic_if_not(in_size_ % num_ch_ == 0 && in_pos_ % num_ch_ == 0
+                         && in_pos_ <= in_size_);
+        roc_panic_if_not(out_size % num_ch_ == 0 && out_pos % num_ch_ == 0
+                         && out_pos <= out_size);
+
+        if (in_pos_ == in_size_ && use_inner_resampler_) {
+            // no more samples in input frame, but maybe inner resampler has more?
+            // try to refill our buffer and start reading from it
+            in_size_ = inner_resampler_->pop_output(in_buf_.data(), in_buf_.size());
+            in_pos_ = 0;
+            out_acc_ += in_size_ / multiplier_;
+        }
+
+        if (in_pos_ == in_size_) {
+            // no more samples in input frame and inner resampler
+            // caller should push more input samples
+            break;
+        }
+
+        if (floorf(out_acc_) >= float(in_size_ - in_pos_) + num_ch_) {
+            // accumulator is ahead of input by at least num_ch samples
+            // duplicate num_ch input samples to compensate
+            memcpy(out_data + out_pos, last_buf_.data(), num_ch_ * sizeof(sample_t));
+            out_pos += num_ch_;
+            out_acc_ -= num_ch_;
+            // for reports
+            decim_count_ += num_ch_;
+        } else if (ceilf(out_acc_) <= float(in_size_ - in_pos_) - num_ch_) {
+            // accumulator is behind of input by at least num_ch samples
+            // skip num_ch input samples to compensate
+            in_pos_ += num_ch_;
+            // for reports
+            decim_count_ += num_ch_;
+        }
+
+        // copy input samples to output
+        const size_t copy_size = std::min(in_size_ - in_pos_, out_size - out_pos);
+
+        if (copy_size != 0) {
+            roc_panic_if_not(copy_size % num_ch_ == 0);
+
+            memcpy(out_data + out_pos, in_buf_.data() + in_pos_,
+                   copy_size * sizeof(sample_t));
+
+            out_pos += copy_size;
+            in_pos_ += copy_size;
+            out_acc_ -= copy_size;
+
+            // remember last num_ch samples of last frame
+            memcpy(last_buf_.data(), out_data + out_pos - num_ch_,
+                   num_ch_ * sizeof(sample_t));
+        }
+    }
+
+    // for reports
+    total_count_ += out_pos;
+
+    report_stats_();
+
+    return out_pos;
+}
+
+float DecimationResampler::n_left_to_process() const {
+    roc_panic_if_not(is_valid());
+
+    // how much samples are pending in our buffer
+    float n_samples = float(in_size_ - in_pos_) / output_spec_.sample_rate()
+        * input_spec_.sample_rate();
+
+    if (use_inner_resampler_) {
+        // how much samples are pending in inner resampler
+        n_samples += inner_resampler_->n_left_to_process();
+    }
+
+    return n_samples;
+}
+
+void DecimationResampler::report_stats_() {
+    if (!report_limiter_.allow()) {
+        return;
+    }
+
+    // number of insertions/duplications per channel per second
+    const float decim_ratio = ((float)decim_count_ / num_ch_)
+        / ((float)output_spec_.samples_overall_2_ns(total_count_) / core::Second);
+
+    total_count_ = 0;
+    decim_count_ = 0;
+
+    roc_log(LogDebug, "decimation resampler: mult=%.6f ratio=%.3f samples/sec",
+            (double)multiplier_, (double)decim_ratio);
+}
+
+} // namespace audio
+} // namespace roc

--- a/src/internal_modules/roc_audio/decimation_resampler.h
+++ b/src/internal_modules/roc_audio/decimation_resampler.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_audio/decimation_resampler.h
+//! @brief Decimating resampler.
+
+#ifndef ROC_AUDIO_DECIMATION_RESAMPLER_H_
+#define ROC_AUDIO_DECIMATION_RESAMPLER_H_
+
+#include "roc_audio/frame.h"
+#include "roc_audio/iframe_reader.h"
+#include "roc_audio/iresampler.h"
+#include "roc_audio/sample.h"
+#include "roc_audio/sample_spec.h"
+#include "roc_core/buffer_factory.h"
+#include "roc_core/noncopyable.h"
+#include "roc_core/rate_limiter.h"
+#include "roc_core/slice.h"
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace audio {
+
+//! Decimating resampler.
+//!
+//! Acts as decorator for another resampler instance.
+//!
+//! Performs resampling in two stages:
+//!  - first, uses underlying resampler to apply constant part of scaling factor based
+//!    on input and output rates; if these rates are equal, first stage is skipped
+//!  - then, uses decimation or duplication to apply dynamic part of scaling
+//!    factor, a.k.a. multiplier, by dropping or duplicating samples
+//!
+//! When input and output rates are the same, this backend implements fastest possible
+//! resampling algorithm working almost at the speed of memcpy().
+//!
+//! Although decimation usually degrades quality a lot, it's not so dramatic in this
+//! specific case because we use it only for dynamic part of scaling factor, which in
+//! practice is very close to 1.0, and typically we remove or insert up to 20 samples
+//! per second or so on 48kHz, which corresponds to ~ 0.4ms/second.
+//!
+//! When input and output rates are different, this backend uses another, underlying
+//! resampler, but only for converting between input and output rates. It still uses
+//! decimation or duplication for applying dynamic part of scaling factor.
+class DecimationResampler : public IResampler, public core::NonCopyable<> {
+public:
+    //! Initialize.
+    DecimationResampler(const core::SharedPtr<IResampler>& inner_resampler,
+                        core::IArena& arena,
+                        core::BufferFactory<sample_t>& buffer_factory,
+                        const audio::SampleSpec& in_spec,
+                        const audio::SampleSpec& out_spec);
+
+    ~DecimationResampler();
+
+    //! Check if object is successfully constructed.
+    virtual bool is_valid() const;
+
+    //! Set new resample factor.
+    virtual bool set_scaling(size_t input_rate, size_t output_rate, float multiplier);
+
+    //! Get buffer to be filled with input data.
+    virtual const core::Slice<sample_t>& begin_push_input();
+
+    //! Commit buffer with input data.
+    virtual void end_push_input();
+
+    //! Read samples from input frame and fill output frame.
+    virtual size_t pop_output(sample_t* out_data, size_t out_size);
+
+    //! How many samples were pushed but not processed yet.
+    virtual float n_left_to_process() const;
+
+private:
+    void report_stats_();
+
+    const core::SharedPtr<IResampler> inner_resampler_;
+    bool use_inner_resampler_;
+
+    audio::SampleSpec input_spec_;
+    audio::SampleSpec output_spec_;
+    float multiplier_;
+
+    const size_t num_ch_;
+
+    core::Slice<sample_t> in_buf_;
+    size_t in_size_;
+    size_t in_pos_;
+
+    float out_acc_;
+
+    core::Slice<sample_t> last_buf_;
+
+    size_t total_count_;
+    size_t decim_count_;
+    core::RateLimiter report_limiter_;
+
+    bool valid_;
+};
+
+} // namespace audio
+} // namespace roc
+
+#endif // ROC_AUDIO_DECIMATION_RESAMPLER_H_

--- a/src/internal_modules/roc_audio/resampler_backend.cpp
+++ b/src/internal_modules/roc_audio/resampler_backend.cpp
@@ -19,6 +19,9 @@ const char* resampler_backend_to_str(ResamplerBackend backend) {
     case ResamplerBackend_Speex:
         return "speex";
 
+    case ResamplerBackend_SpeexDec:
+        return "speexdec";
+
     case ResamplerBackend_Default:
         return "default";
     }

--- a/src/internal_modules/roc_audio/resampler_backend.h
+++ b/src/internal_modules/roc_audio/resampler_backend.h
@@ -18,18 +18,23 @@ namespace audio {
 //! Resampler backends.
 enum ResamplerBackend {
     //! Default backend.
-    //! Resolved to some of other backends, depending
-    //! on what is supported.
+    //! Resolved to one of other backends, depending on what
+    //! is enabled at build time.
     ResamplerBackend_Default,
 
     //! Built-in resampler.
-    //! High precision, slow.
+    //! High precision, high quality, slow.
     ResamplerBackend_Builtin,
 
     //! SpeexDSP resampler.
-    //! Lower precision, fast.
+    //! Low precision, high quality, fast.
     //! May be disabled at build time.
-    ResamplerBackend_Speex
+    ResamplerBackend_Speex,
+
+    //! Combined SpeexDSP + decimating resampler.
+    //! Tolerable precision, tolerable quality, fast.
+    //! May be disabled at build time.
+    ResamplerBackend_SpeexDec
 };
 
 //! Get string name of resampler backend.

--- a/src/internal_modules/roc_audio/resampler_map.h
+++ b/src/internal_modules/roc_audio/resampler_map.h
@@ -56,7 +56,7 @@ public:
 private:
     friend class core::Singleton<ResamplerMap>;
 
-    enum { MaxBackends = 2 };
+    enum { MaxBackends = 4 };
 
     struct Backend {
         Backend()

--- a/src/public_api/src/adapters.cpp
+++ b/src/public_api/src/adapters.cpp
@@ -444,6 +444,10 @@ bool resampler_backend_from_user(audio::ResamplerBackend& out, roc_resampler_bac
     case ROC_RESAMPLER_BACKEND_SPEEX:
         out = audio::ResamplerBackend_Speex;
         return true;
+
+    case ROC_RESAMPLER_BACKEND_SPEEXDEC:
+        out = audio::ResamplerBackend_SpeexDec;
+        return true;
     }
 
     return false;

--- a/src/tests/roc_audio/test_helpers/mock_reader.h
+++ b/src/tests/roc_audio/test_helpers/mock_reader.h
@@ -88,7 +88,7 @@ public:
     }
 
 private:
-    enum { MaxSz = 64 * 1024 };
+    enum { MaxSz = 100000 };
 
     size_t total_reads_;
 

--- a/src/tools/roc_copy/cmdline.ggo
+++ b/src/tools/roc_copy/cmdline.ggo
@@ -21,7 +21,7 @@ section "Options"
         int optional
 
     option "resampler-backend" - "Resampler backend"
-        values="default","builtin","speex" default="default" enum optional
+        values="default","builtin","speex","speexdec" default="default" enum optional
 
     option "resampler-profile" - "Resampler profile"
         values="low","medium","high" default="medium" enum optional

--- a/src/tools/roc_copy/main.cpp
+++ b/src/tools/roc_copy/main.cpp
@@ -144,6 +144,9 @@ int main(int argc, char** argv) {
     case resampler_backend_arg_speex:
         transcoder_config.resampler_backend = audio::ResamplerBackend_Speex;
         break;
+    case resampler_backend_arg_speexdec:
+        transcoder_config.resampler_backend = audio::ResamplerBackend_SpeexDec;
+        break;
     default:
         break;
     }

--- a/src/tools/roc_recv/cmdline.ggo
+++ b/src/tools/roc_recv/cmdline.ggo
@@ -63,7 +63,7 @@ section "Options"
         values="default","responsive","gradual" default="default" enum optional
 
     option "resampler-backend" - "Resampler backend"
-        values="default","builtin","speex" default="default" enum optional
+        values="default","builtin","speex","speexdec" default="default" enum optional
 
     option "resampler-profile" - "Resampler profile"
         values="low","medium","high" default="medium" enum optional

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -205,6 +205,10 @@ int main(int argc, char** argv) {
     case resampler_backend_arg_speex:
         receiver_config.default_session.resampler_backend = audio::ResamplerBackend_Speex;
         break;
+    case resampler_backend_arg_speexdec:
+        receiver_config.default_session.resampler_backend =
+            audio::ResamplerBackend_SpeexDec;
+        break;
     default:
         break;
     }

--- a/src/tools/roc_send/cmdline.ggo
+++ b/src/tools/roc_send/cmdline.ggo
@@ -47,7 +47,7 @@ section "Options"
     option "no-resampling" - "Disable resampling" flag off
 
     option "resampler-backend" - "Resampler backend"
-        values="default","builtin","speex" default="default" enum optional
+        values="default","builtin","speex","speexdec" default="default" enum optional
 
     option "resampler-profile" - "Resampler profile"
         values="low","medium","high" default="medium" enum optional

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -172,6 +172,9 @@ int main(int argc, char** argv) {
     case resampler_backend_arg_speex:
         sender_config.resampler_backend = audio::ResamplerBackend_Speex;
         break;
+    case resampler_backend_arg_speexdec:
+        sender_config.resampler_backend = audio::ResamplerBackend_SpeexDec;
+        break;
     default:
         break;
     }


### PR DESCRIPTION
PR contains 3 commits:

* relax requirements in resampler tests: use more smooth input, and 99% percentile for input & output comparisons
* implement DecimationResampler (decorator for IResampler that add decimation for dynamic part of scaling factor, a.k.a. multiplier), and register "speexdec" backend that combines DecimationResampler + SpeexResampler
* improve resampler tests: cleanup, cover multiple rates and profiles, add "scaling_trend" test