### PR TITLE
Implement lock-free fast_random function

### DIFF
--- a/src/internal_modules/roc_audio/packetizer.cpp
+++ b/src/internal_modules/roc_audio/packetizer.cpp
@@ -34,10 +34,11 @@ Packetizer::Packetizer(packet::IWriter& writer,
     , payload_size_(payload_encoder.encoded_byte_count(samples_per_packet_))
     , packet_pos_(0)
     , valid_(false) {
-    source_ = (packet::stream_source_t)core::fast_random(0, packet::stream_source_t(-1));
-    seqnum_ = (packet::seqnum_t)core::fast_random(0, packet::seqnum_t(-1));
-    stream_ts_ =
-        (packet::stream_timestamp_t)core::fast_random(0, packet::stream_timestamp_t(-1));
+    source_ =
+        (packet::stream_source_t)core::fast_random_range(0, packet::stream_source_t(-1));
+    seqnum_ = (packet::seqnum_t)core::fast_random_range(0, packet::seqnum_t(-1));
+    stream_ts_ = (packet::stream_timestamp_t)core::fast_random_range(
+        0, packet::stream_timestamp_t(-1));
     capture_ts_ = 0;
     valid_ = true;
     roc_log(LogDebug, "packetizer: initializing: n_channels=%lu samples_per_packet=%lu",

--- a/src/internal_modules/roc_core/fast_random.cpp
+++ b/src/internal_modules/roc_core/fast_random.cpp
@@ -6,11 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <stdlib.h>
-
-#include "roc_core/atomic_ops.h"
-#include "roc_core/errno_to_str.h"
 #include "roc_core/fast_random.h"
+#include "roc_core/atomic_ops.h"
 #include "roc_core/panic.h"
 #include "roc_core/time.h"
 

--- a/src/internal_modules/roc_core/fast_random.h
+++ b/src/internal_modules/roc_core/fast_random.h
@@ -21,6 +21,10 @@ namespace core {
 //! Thread-safe.
 //! @returns random value in range [from; to].
 uint32_t fast_random_range(uint32_t from, uint32_t to);
+
+//! Get a random integer from a non cryptographically secure, but fast PRNG.
+//! Thread-safe.
+//! @returns random value between 0 and UINT32_MAX.
 uint32_t fast_random();
 
 } // namespace core

--- a/src/internal_modules/roc_core/fast_random.h
+++ b/src/internal_modules/roc_core/fast_random.h
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-//! @file roc_core/target_posix/roc_core/fast_random.h
+//! @file roc_core/fast_random.h
 //! @brief Helpers to work with random numbers.
 
 #ifndef ROC_CORE_FAST_RANDOM_H_
@@ -20,7 +20,8 @@ namespace core {
 //! Get a random integer from a non cryptographically secure, but fast PRNG.
 //! Thread-safe.
 //! @returns random value in range [from; to].
-uint32_t fast_random(uint32_t from, uint32_t to);
+uint32_t fast_random_range(uint32_t from, uint32_t to);
+uint32_t fast_random();
 
 } // namespace core
 } // namespace roc

--- a/src/internal_modules/roc_core/hashmap.h
+++ b/src/internal_modules/roc_core/hashmap.h
@@ -352,11 +352,11 @@ private:
         LoadFactorDen = 2,
 
         // how much buckets are embeded directly into Hashmap object
-        NumEmbeddedBuckets = ((int)(EmbeddedCapacity == 0        ? 0
-                                        : EmbeddedCapacity <= 16 ? 16
-                                                                 : EmbeddedCapacity)
-                                  * LoadFactorDen
-                              + LoadFactorNum - 1)
+        NumEmbeddedBuckets =
+            ((int)(EmbeddedCapacity == 0 ? 0
+                                         : EmbeddedCapacity <= 16 ? 16 : EmbeddedCapacity)
+                 * LoadFactorDen
+             + LoadFactorNum - 1)
             / LoadFactorNum * 2
     };
 

--- a/src/internal_modules/roc_core/hashmap.h
+++ b/src/internal_modules/roc_core/hashmap.h
@@ -352,11 +352,11 @@ private:
         LoadFactorDen = 2,
 
         // how much buckets are embeded directly into Hashmap object
-        NumEmbeddedBuckets =
-            ((int)(EmbeddedCapacity == 0 ? 0
-                                         : EmbeddedCapacity <= 16 ? 16 : EmbeddedCapacity)
-                 * LoadFactorDen
-             + LoadFactorNum - 1)
+        NumEmbeddedBuckets = ((int)(EmbeddedCapacity == 0        ? 0
+                                        : EmbeddedCapacity <= 16 ? 16
+                                                                 : EmbeddedCapacity)
+                                  * LoadFactorDen
+                              + LoadFactorNum - 1)
             / LoadFactorNum * 2
     };
 

--- a/src/internal_modules/roc_core/target_posix/roc_core/fast_random.cpp
+++ b/src/internal_modules/roc_core/target_posix/roc_core/fast_random.cpp
@@ -9,6 +9,7 @@
 #include <pthread.h>
 #include <stdlib.h>
 
+#include "roc_core/atomic_ops.h"
 #include "roc_core/errno_to_str.h"
 #include "roc_core/fast_random.h"
 #include "roc_core/panic.h"
@@ -19,20 +20,32 @@ namespace core {
 
 namespace {
 
-pthread_mutex_t rand_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_once_t once_control = PTHREAD_ONCE_INIT;
 
-bool rand_init = false;
+uint32_t state;
 
-unsigned short rand_seed[3] = {};
+void init_state() {
+    const nanoseconds_t seed_48 = timestamp(ClockMonotonic);
+    state = (uint32_t)seed_48;
+}
+
+inline uint32_t splitmix32(uint32_t z) {
+    z = z ^ (z >> 16);
+    z *= 0x21F0AAAD;
+    z = z ^ (z >> 15);
+    z *= 0x735A2D97;
+    z = z ^ (z >> 15);
+    return z;
+}
 
 } // namespace
 
 // The implementation is based on "Debiased Modulo (Once) — Java's Method" algorithm
 // from https://www.pcg-random.org/posts/bounded-rands.html
 //
-// We use nrand48(), which is thread-safe on most platforms. It is probably not fully
-// thread-safe on glibc when used concurrently with lcong48(), but most likely the
-// race is harmless. See https://www.evanjones.ca/random-thread-safe.html.
+// We use splitmix32 as a PRNG
+// shifts and multiplcation value were taken from link below
+// https://gist.github.com/tommyettinger/46a874533244883189143505d203312c?permalink_comment_id=4365431#gistcomment-4365431
 //
 // This implementation is not a cryptographically secure PRNG.
 uint32_t fast_random(uint32_t from, uint32_t to) {
@@ -40,28 +53,17 @@ uint32_t fast_random(uint32_t from, uint32_t to) {
 
     const uint64_t range = uint64_t(to) - from + 1;
 
-    uint64_t x, r;
+    uint64_t z, r;
 
-    if (int err = pthread_mutex_lock(&rand_mutex)) {
-        roc_panic("fast random: pthread_mutex_lock(): %s", errno_to_str(err).c_str());
-    }
-
-    if (!rand_init) {
-        rand_init = true;
-        const nanoseconds_t seed_48 = timestamp(ClockMonotonic);
-        rand_seed[0] = (seed_48 & 0xffff);
-        rand_seed[1] = ((seed_48 >> 16) & 0xffff);
-        rand_seed[2] = ((seed_48 >> 32) & 0xffff);
+    if (int err = pthread_once(&once_control, init_state)) {
+        roc_panic("fast random: pthread_once(): %s", errno_to_str(err).c_str());
     }
 
     do {
-        x = (uint64_t)nrand48(rand_seed);
-        r = x % range;
-    } while (x - r > (-range));
-
-    if (int err = pthread_mutex_unlock(&rand_mutex)) {
-        roc_panic("fast random: pthread_mutex_unlock(): %s", errno_to_str(err).c_str());
-    }
+        z = AtomicOps::fetch_add_seq_cst(state, 0x9E3779B9);
+        z = splitmix32(z);
+        r = z % range;
+    } while (z - r > (-range));
 
     const uint32_t ret = from + (uint32_t)r;
 

--- a/src/internal_modules/roc_fec/writer.cpp
+++ b/src/internal_modules/roc_fec/writer.cpp
@@ -41,8 +41,9 @@ Writer::Writer(const WriterConfig& config,
     , fec_scheme_(fec_scheme)
     , valid_(false)
     , alive_(true) {
-    cur_sbn_ = (packet::blknum_t)core::fast_random(0, packet::blknum_t(-1));
-    cur_block_repair_sn_ = (packet::seqnum_t)core::fast_random(0, packet::seqnum_t(-1));
+    cur_sbn_ = (packet::blknum_t)core::fast_random_range(0, packet::blknum_t(-1));
+    cur_block_repair_sn_ =
+        (packet::seqnum_t)core::fast_random_range(0, packet::seqnum_t(-1));
     if (!resize(config.n_source_packets, config.n_repair_packets)) {
         return;
     }

--- a/src/internal_modules/roc_packet/interleaver.cpp
+++ b/src/internal_modules/roc_packet/interleaver.cpp
@@ -81,7 +81,7 @@ void Interleaver::reinit_seq_() {
         send_seq_[i] = i;
     }
     for (size_t i = block_size_; i > 0; --i) {
-        const size_t j = core::fast_random(0, (unsigned int)i - 1);
+        const size_t j = core::fast_random_range(0, (unsigned int)i - 1);
         const size_t buff = send_seq_[i - 1];
         send_seq_[i - 1] = send_seq_[j];
         send_seq_[j] = buff;

--- a/src/internal_modules/roc_rtcp/session.cpp
+++ b/src/internal_modules/roc_rtcp/session.cpp
@@ -31,7 +31,8 @@ Session::Session(IReceiverHooks* recv_hooks,
     , next_deadline_(0)
     , ssrc_(0)
     , valid_(false) {
-    ssrc_ = (packet::stream_source_t)core::fast_random(0, packet::stream_source_t(-1));
+    ssrc_ =
+        (packet::stream_source_t)core::fast_random_range(0, packet::stream_source_t(-1));
 
     // TODO
     strcpy(cname_, "TODO");

--- a/src/tests/roc_core/bench_random.cpp
+++ b/src/tests/roc_core/bench_random.cpp
@@ -17,7 +17,7 @@ namespace {
 void BM_Random_Fast(benchmark::State& state) {
     uint32_t r = 0;
     while (state.KeepRunning()) {
-        r = fast_random(r, (uint32_t)-1);
+        r = fast_random_range(r, (uint32_t)-1);
         benchmark::DoNotOptimize(r);
     }
 }

--- a/src/tests/roc_core/test_fast_random.cpp
+++ b/src/tests/roc_core/test_fast_random.cpp
@@ -20,20 +20,20 @@ TEST_GROUP(fast_random) {};
 
 TEST(fast_random, min_min) {
     uint32_t lo_hi = 0;
-    uint32_t res = fast_random(lo_hi, lo_hi);
+    uint32_t res = fast_random_range(lo_hi, lo_hi);
 
     LONGS_EQUAL(res, lo_hi);
 }
 
 TEST(fast_random, max_max) {
     uint32_t lo_hi = UINT32_MAX;
-    uint32_t res = fast_random(lo_hi, lo_hi);
+    uint32_t res = fast_random_range(lo_hi, lo_hi);
 
     LONGS_EQUAL(res, lo_hi);
 }
 
 TEST(fast_random, limits) {
-    uint32_t res = fast_random(1, 100);
+    uint32_t res = fast_random_range(1, 100);
 
     CHECK(1 <= res && res <= 100);
 }

--- a/src/tests/roc_ctl/bench_task_queue_contention.cpp
+++ b/src/tests/roc_ctl/bench_task_queue_contention.cpp
@@ -80,7 +80,7 @@ BENCHMARK_DEFINE_F(BM_QueueContention, ScheduleAt)(benchmark::State& state) {
 
     core::nanoseconds_t* delays = new core::nanoseconds_t[NumScheduleAfterIterations];
     for (int n = 0; n < NumScheduleAfterIterations; n++) {
-        delays[n] = core::fast_random(0, MaxDelay);
+        delays[n] = core::fast_random_range(0, MaxDelay);
     }
 
     while (state.KeepRunningBatch(BatchSize)) {

--- a/src/tests/roc_fec/test_encoder_decoder.cpp
+++ b/src/tests/roc_fec/test_encoder_decoder.cpp
@@ -84,7 +84,7 @@ private:
         core::Slice<uint8_t> buf = buffer_factory.new_buffer();
         buf.reslice(0, p_size);
         for (size_t j = 0; j < buf.size(); ++j) {
-            buf.data()[j] = (uint8_t)core::fast_random(0, 0xff);
+            buf.data()[j] = (uint8_t)core::fast_random_range(0, 0xff);
         }
         return buf;
     }
@@ -170,7 +170,8 @@ TEST(encoder_decoder, random_losses) {
 
             size_t curr_loss = 0;
             for (size_t i = 0; i < NumSourcePackets + NumRepairPackets; ++i) {
-                if (core::fast_random(0, 100) < LossPercent && curr_loss <= MaxLoss) {
+                if (core::fast_random_range(0, 100) < LossPercent
+                    && curr_loss <= MaxLoss) {
                     total_loss++;
                     curr_loss++;
                 } else {

--- a/src/tests/roc_netio/test_helpers/conn_reader.h
+++ b/src/tests/roc_netio/test_helpers/conn_reader.h
@@ -43,7 +43,7 @@ private:
             handler_.wait_readable();
 
             while (num_read < total_bytes_) {
-                size_t bufsz = core::fast_random(1, MaxBatch);
+                size_t bufsz = core::fast_random_range(1, MaxBatch);
                 if (bufsz > (total_bytes_ - num_read)) {
                     bufsz = (total_bytes_ - num_read);
                 }

--- a/src/tests/roc_netio/test_helpers/conn_writer.h
+++ b/src/tests/roc_netio/test_helpers/conn_writer.h
@@ -44,12 +44,13 @@ private:
             handler_.wait_writable();
 
             while (num_written < total_bytes_) {
-                const core::nanoseconds_t delay = (core::nanoseconds_t)core::fast_random(
-                    0, MaxDelayNs * core::Nanosecond);
+                const core::nanoseconds_t delay =
+                    (core::nanoseconds_t)core::fast_random_range(
+                        0, MaxDelayNs * core::Nanosecond);
 
                 core::sleep_for(core::ClockMonotonic, delay);
 
-                size_t bufsz = core::fast_random(1, MaxBatch);
+                size_t bufsz = core::fast_random_range(1, MaxBatch);
                 if (bufsz > (total_bytes_ - num_written)) {
                     bufsz = (total_bytes_ - num_written);
                 }

--- a/src/tests/roc_pipeline/bench_pipeline_loop_peak_load.cpp
+++ b/src/tests/roc_pipeline/bench_pipeline_loop_peak_load.cpp
@@ -336,8 +336,8 @@ private:
     virtual bool process_task_imp(PipelineTask& basic_task) {
         Task& task = (Task&)basic_task;
         stats_.task_processing_started(task.elapsed_time());
-        busy_wait(
-            core::fast_random(MinTaskProcessingDuration, MaxTaskProcessingDuration));
+        busy_wait(core::fast_random_range(MinTaskProcessingDuration,
+                                          MaxTaskProcessingDuration));
         return true;
     }
 
@@ -375,9 +375,9 @@ private:
     virtual void run() {
         while (!stop_) {
             core::sleep_for(core::ClockMonotonic,
-                            core::fast_random(MinTaskDelay, MaxTaskDelay));
+                            core::fast_random_range(MinTaskDelay, MaxTaskDelay));
 
-            const size_t n_tasks = core::fast_random(MinTaskBurst, MaxTaskBurst);
+            const size_t n_tasks = core::fast_random_range(MinTaskBurst, MaxTaskBurst);
 
             for (size_t n = 0; n < n_tasks; n++) {
                 TestPipeline::Task* task = new TestPipeline::Task;


### PR DESCRIPTION
Commit for #426

- nrand48() is replaced with splitmix32()
- obtaining the seed is now an atomic fetch and add
- replaced pthread_mutex_lock and unlock with single pthread_once() call to an state initialization function for the seed