### PR TITLE
Heap arena canary guards

### DIFF
--- a/src/internal_modules/roc_core/heap_arena.cpp
+++ b/src/internal_modules/roc_core/heap_arena.cpp
@@ -40,6 +40,10 @@ size_t HeapArena::num_allocations() const {
     return (size_t)num_allocations_;
 }
 
+size_t HeapArena::num_guard_failures() const {
+    return num_guard_failures_;
+}
+
 void* HeapArena::allocate(size_t size) {
     num_allocations_++;
 
@@ -102,8 +106,5 @@ void HeapArena::deallocate(void* ptr) {
     free(chunk);
 }
 
-size_t HeapArena::num_guard_failures() const {
-    return num_guard_failures_;
-}
 } // namespace core
 } // namespace roc

--- a/src/internal_modules/roc_core/heap_arena.h
+++ b/src/internal_modules/roc_core/heap_arena.h
@@ -22,8 +22,10 @@ namespace core {
 
 //! Heap arena flags.
 enum HeapArenaFlags {
+    //! Enable leak detection, etc.
+    HeapArenaFlag_EnableLeakDetection = (1 << 0),
     //! Enable guards such as canary, etc.
-    HeapArenaFlag_EnableGuards = (1 << 0),
+    HeapArenaFlag_EnableGuards = (1 << 1),
 };
 
 //! Default heap arena flags.
@@ -40,14 +42,14 @@ enum { DefaultHeapArenaFlags = (HeapArenaFlag_EnableGuards) };
 class HeapArena : public IArena, public NonCopyable<> {
 public:
     //! Initialize.
+    HeapArena();
+    ~HeapArena();
+
+    //! Set flags, for all instances.
     //!
     //! @b Parameters
     //! - @p flags defines options to modify behaviour as indicated in HeapArenaFlags
-    HeapArena(size_t flags = DefaultHeapArenaFlags);
-    ~HeapArena();
-
-    //! Enable panic on leak in destructor, for all instances.
-    static void enable_leak_detection();
+    static void set_flags(size_t flags);
 
     //! Get number of allocated blocks.
     size_t num_allocations() const;
@@ -62,17 +64,18 @@ public:
     size_t num_guard_failures() const;
 
 private:
-    struct Chunk {
+    struct ChunkHeader {
         size_t size;
         AlignMax data[];
     };
 
     typedef AlignMax ChunkCanary;
 
-    static int enable_leak_detection_;
-
     Atomic<int> num_allocations_;
-    size_t flags_;
+
+    static int enable_leak_detection_;
+    static int enable_guards_;
+
     size_t num_guard_failures_;
 };
 

--- a/src/internal_modules/roc_core/heap_arena.h
+++ b/src/internal_modules/roc_core/heap_arena.h
@@ -39,6 +39,10 @@ enum { DefaultHeapArenaFlags = (HeapArenaFlag_EnableGuards) };
 //! The memory is always maximum aligned. Thread-safe.
 class HeapArena : public IArena, public NonCopyable<> {
 public:
+    //! Initialize.
+    //!
+    //! @b Parameters
+    //! - @p flags defines options to modify behaviour as indicated in HeapArenaFlags
     HeapArena(size_t flags = DefaultHeapArenaFlags);
     ~HeapArena();
 

--- a/src/internal_modules/roc_core/heap_arena.h
+++ b/src/internal_modules/roc_core/heap_arena.h
@@ -73,8 +73,7 @@ private:
 
     Atomic<int> num_allocations_;
 
-    static int enable_leak_detection_;
-    static int enable_guards_;
+    static size_t flags_;
 
     size_t num_guard_failures_;
 };

--- a/src/internal_modules/roc_core/heap_arena.h
+++ b/src/internal_modules/roc_core/heap_arena.h
@@ -22,9 +22,9 @@ namespace core {
 
 //! Heap arena flags.
 enum HeapArenaFlags {
-    //! Enable leak detection, etc.
+    //! Enable panic if leaks detected in arena destructor.
     HeapArenaFlag_EnableLeakDetection = (1 << 0),
-    //! Enable guards such as canary, etc.
+    //! Enable panic if memory violation detected when deallocating chunk.
     HeapArenaFlag_EnableGuards = (1 << 1),
 };
 
@@ -54,14 +54,14 @@ public:
     //! Get number of allocated blocks.
     size_t num_allocations() const;
 
+    //! Get number of guard failures.
+    size_t num_guard_failures() const;
+
     //! Allocate memory.
     virtual void* allocate(size_t size);
 
     //! Deallocate previously allocated memory.
     virtual void deallocate(void*);
-
-    //! Get number of guard failures.
-    size_t num_guard_failures() const;
 
 private:
     struct ChunkHeader {

--- a/src/internal_modules/roc_core/heap_arena.h
+++ b/src/internal_modules/roc_core/heap_arena.h
@@ -20,6 +20,15 @@
 namespace roc {
 namespace core {
 
+//! Heap arena flags.
+enum HeapArenaFlags {
+    //! Enable guards such as canary, etc.
+    HeapArenaFlag_EnableGuards = (1 << 0),
+};
+
+//! Default heap arena flags.
+enum { DefaultHeapArenaFlags = (HeapArenaFlag_EnableGuards) };
+
 //! Heap arena implementation.
 //!
 //! Uses malloc() and free().
@@ -30,7 +39,7 @@ namespace core {
 //! The memory is always maximum aligned. Thread-safe.
 class HeapArena : public IArena, public NonCopyable<> {
 public:
-    HeapArena();
+    HeapArena(size_t flags = DefaultHeapArenaFlags);
     ~HeapArena();
 
     //! Enable panic on leak in destructor, for all instances.
@@ -45,6 +54,9 @@ public:
     //! Deallocate previously allocated memory.
     virtual void deallocate(void*);
 
+    //! Get number of guard failures.
+    size_t num_guard_failures() const;
+
 private:
     struct Chunk {
         size_t size;
@@ -56,6 +68,8 @@ private:
     static int enable_leak_detection_;
 
     Atomic<int> num_allocations_;
+    size_t flags_;
+    size_t num_guard_failures_;
 };
 
 } // namespace core

--- a/src/internal_modules/roc_core/heap_arena.h
+++ b/src/internal_modules/roc_core/heap_arena.h
@@ -51,6 +51,8 @@ private:
         AlignMax data[];
     };
 
+    typedef AlignMax ChunkCanary;
+
     static int enable_leak_detection_;
 
     Atomic<int> num_allocations_;

--- a/src/tests/bench_main.cpp
+++ b/src/tests/bench_main.cpp
@@ -15,7 +15,8 @@
 using namespace roc;
 
 int main(int argc, char** argv) {
-    core::HeapArena::enable_leak_detection();
+    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                               | core::HeapArenaFlag_EnableLeakDetection);
 
     core::CrashHandler crash_handler;
 

--- a/src/tests/roc_core/test_heap_arena.cpp
+++ b/src/tests/roc_core/test_heap_arena.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <CppUTest/TestHarness.h>
+
+#include "roc_core/heap_arena.h"
+#include "roc_core/memory_ops.h"
+
+namespace roc {
+namespace core {
+
+TEST_GROUP(heap_arena) {};
+
+TEST(heap_arena, guard_object) {
+    HeapArena arena((DefaultHeapArenaFlags & ~HeapArenaFlag_EnableGuards));
+    void* pointer = NULL;
+
+    pointer = arena.allocate(128);
+    CHECK(pointer);
+
+    char* data = (char*)pointer;
+    char* before_data = data - 1;
+    char* after_data = data + 128;
+    CHECK(*before_data == MemoryOps::Pattern_Canary);
+    CHECK(*after_data == MemoryOps::Pattern_Canary);
+
+    arena.deallocate(pointer);
+}
+
+TEST(heap_arena, guard_object_violations) {
+    HeapArena arena((DefaultHeapArenaFlags & ~HeapArenaFlag_EnableGuards));
+
+    void* pointers[2] = {};
+
+    pointers[0] = arena.allocate(127);
+    CHECK(pointers[0]);
+
+    pointers[1] = arena.allocate(128);
+    CHECK(pointers[1]);
+
+    {
+        char* data = (char*)pointers[0];
+        data--;
+        *data = 0x00;
+    }
+    arena.deallocate(pointers[0]);
+    CHECK(arena.num_guard_failures() == 1);
+
+    {
+        char* data = (char*)pointers[1];
+        data += 128;
+        *data = 0x00;
+    }
+    arena.deallocate(pointers[1]);
+    CHECK(arena.num_guard_failures() == 2);
+}
+
+} // namespace core
+} // namespace roc

--- a/src/tests/roc_core/test_heap_arena.cpp
+++ b/src/tests/roc_core/test_heap_arena.cpp
@@ -14,12 +14,17 @@
 namespace roc {
 namespace core {
 
-TEST_GROUP(heap_arena) {};
+TEST_GROUP(heap_arena) {
+    void setup() { core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                                              & ~core::HeapArenaFlag_EnableGuards);
+}
+void teardown() {
+    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                               | core::HeapArenaFlag_EnableGuards);
+}
+}; // namespace roc
 
 TEST(heap_arena, guard_object) {
-    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                               & ~core::HeapArenaFlag_EnableGuards);
-
     HeapArena arena;
     void* pointer = NULL;
 
@@ -33,13 +38,9 @@ TEST(heap_arena, guard_object) {
     CHECK(*after_data == MemoryOps::Pattern_Canary);
 
     arena.deallocate(pointer);
-    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                               | core::HeapArenaFlag_EnableGuards);
 }
 
 TEST(heap_arena, guard_object_violations) {
-    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                               & ~core::HeapArenaFlag_EnableGuards);
     HeapArena arena;
 
     void* pointers[2] = {};
@@ -65,9 +66,6 @@ TEST(heap_arena, guard_object_violations) {
     }
     arena.deallocate(pointers[1]);
     CHECK(arena.num_guard_failures() == 2);
-
-    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                               | core::HeapArenaFlag_EnableGuards);
 }
 
 } // namespace core

--- a/src/tests/roc_core/test_heap_arena.cpp
+++ b/src/tests/roc_core/test_heap_arena.cpp
@@ -17,7 +17,10 @@ namespace core {
 TEST_GROUP(heap_arena) {};
 
 TEST(heap_arena, guard_object) {
-    HeapArena arena((DefaultHeapArenaFlags & ~HeapArenaFlag_EnableGuards));
+    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                               & ~core::HeapArenaFlag_EnableGuards);
+
+    HeapArena arena;
     void* pointer = NULL;
 
     pointer = arena.allocate(127);
@@ -30,10 +33,14 @@ TEST(heap_arena, guard_object) {
     CHECK(*after_data == MemoryOps::Pattern_Canary);
 
     arena.deallocate(pointer);
+    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                               | core::HeapArenaFlag_EnableGuards);
 }
 
 TEST(heap_arena, guard_object_violations) {
-    HeapArena arena((DefaultHeapArenaFlags & ~HeapArenaFlag_EnableGuards));
+    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                               & ~core::HeapArenaFlag_EnableGuards);
+    HeapArena arena;
 
     void* pointers[2] = {};
 
@@ -58,6 +65,9 @@ TEST(heap_arena, guard_object_violations) {
     }
     arena.deallocate(pointers[1]);
     CHECK(arena.num_guard_failures() == 2);
+
+    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                               | core::HeapArenaFlag_EnableGuards);
 }
 
 } // namespace core

--- a/src/tests/roc_core/test_heap_arena.cpp
+++ b/src/tests/roc_core/test_heap_arena.cpp
@@ -15,13 +15,16 @@ namespace roc {
 namespace core {
 
 TEST_GROUP(heap_arena) {
-    void setup() { core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                                              & ~core::HeapArenaFlag_EnableGuards);
-}
-void teardown() {
-    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                               | core::HeapArenaFlag_EnableGuards);
-}
+    // clang-format off
+    void setup() {
+        core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                                    & ~core::HeapArenaFlag_EnableGuards);
+    }
+    void teardown() {
+        core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                                    | core::HeapArenaFlag_EnableGuards);
+    }
+// clang-format on
 }; // namespace roc
 
 TEST(heap_arena, guard_object) {

--- a/src/tests/roc_core/test_heap_arena.cpp
+++ b/src/tests/roc_core/test_heap_arena.cpp
@@ -14,18 +14,17 @@
 namespace roc {
 namespace core {
 
+// clang-format off
 TEST_GROUP(heap_arena) {
-    // clang-format off
     void setup() {
         core::HeapArena::set_flags(core::DefaultHeapArenaFlags
                                     & ~core::HeapArenaFlag_EnableGuards);
     }
     void teardown() {
-        core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                                    | core::HeapArenaFlag_EnableGuards);
+        core::HeapArena::set_flags(core::DefaultHeapArenaFlags);
     }
+};
 // clang-format on
-}; // namespace roc
 
 TEST(heap_arena, guard_object) {
     HeapArena arena;

--- a/src/tests/roc_core/test_heap_arena.cpp
+++ b/src/tests/roc_core/test_heap_arena.cpp
@@ -20,12 +20,12 @@ TEST(heap_arena, guard_object) {
     HeapArena arena((DefaultHeapArenaFlags & ~HeapArenaFlag_EnableGuards));
     void* pointer = NULL;
 
-    pointer = arena.allocate(128);
+    pointer = arena.allocate(127);
     CHECK(pointer);
 
     char* data = (char*)pointer;
     char* before_data = data - 1;
-    char* after_data = data + 128;
+    char* after_data = data + 127;
     CHECK(*before_data == MemoryOps::Pattern_Canary);
     CHECK(*after_data == MemoryOps::Pattern_Canary);
 
@@ -37,7 +37,7 @@ TEST(heap_arena, guard_object_violations) {
 
     void* pointers[2] = {};
 
-    pointers[0] = arena.allocate(127);
+    pointers[0] = arena.allocate(128);
     CHECK(pointers[0]);
 
     pointers[1] = arena.allocate(128);

--- a/src/tests/test_main.cpp
+++ b/src/tests/test_main.cpp
@@ -18,7 +18,8 @@
 using namespace roc;
 
 int main(int argc, const char** argv) {
-    core::HeapArena::enable_leak_detection();
+    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                               | core::HeapArenaFlag_EnableLeakDetection);
 
     core::CrashHandler crash_handler;
 

--- a/src/tools/roc_copy/main.cpp
+++ b/src/tools/roc_copy/main.cpp
@@ -25,7 +25,8 @@
 using namespace roc;
 
 int main(int argc, char** argv) {
-    core::HeapArena::enable_leak_detection();
+    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                               | core::HeapArenaFlag_EnableLeakDetection);
 
     core::CrashHandler crash_handler;
 

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -31,7 +31,8 @@
 using namespace roc;
 
 int main(int argc, char** argv) {
-    core::HeapArena::enable_leak_detection();
+    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                               | core::HeapArenaFlag_EnableLeakDetection);
 
     core::CrashHandler crash_handler;
 

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -31,7 +31,8 @@
 using namespace roc;
 
 int main(int argc, char** argv) {
-    core::HeapArena::enable_leak_detection();
+    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
+                               | core::HeapArenaFlag_EnableLeakDetection);
 
     core::CrashHandler crash_handler;
 


### PR DESCRIPTION
# Why

For https://github.com/roc-streaming/roc-toolkit/issues/583

# What

* Changed allocate/deallocate to have canary around memory returned to user.
  * Canary after memory includes padding for memory.
* Added flag to enable testing.
* Added test.

# Testing

Added tests.