### PR TITLE
Rework status::code_to_str

### DIFF
--- a/src/internal_modules/roc_audio/depacketizer.cpp
+++ b/src/internal_modules/roc_audio/depacketizer.cpp
@@ -266,7 +266,7 @@ packet::PacketPtr Depacketizer::read_packet_() {
     if (code != status::StatusOK) {
         if (code != status::StatusNoData) {
             // TODO: forward status (gh-302)
-            roc_log(LogError, "depacketizer: failed to read packet: %s",
+            roc_log(LogError, "depacketizer: failed to read packet: status=%s",
                     status::code_to_str(code));
         }
 

--- a/src/internal_modules/roc_fec/reader.cpp
+++ b/src/internal_modules/roc_fec/reader.cpp
@@ -332,7 +332,8 @@ void Reader::fill_source_block_() {
 
         packet::PacketPtr p;
         const status::StatusCode code = source_queue_.read(p);
-        roc_panic_if_msg(code != status::StatusOK, "failed to read source packet: %s",
+        roc_panic_if_msg(code != status::StatusOK,
+                         "failed to read source packet: status=%s",
                          status::code_to_str(code));
         n_fetched++;
 
@@ -400,7 +401,8 @@ void Reader::fill_repair_block_() {
 
         packet::PacketPtr p;
         const status::StatusCode code = repair_queue_.read(p);
-        roc_panic_if_msg(code != status::StatusOK, "failed to read repair packet: %s",
+        roc_panic_if_msg(code != status::StatusOK,
+                         "failed to read repair packet: status=%s",
                          status::code_to_str(code));
         n_fetched++;
 
@@ -774,7 +776,8 @@ void Reader::drop_repair_packets_from_prev_blocks_() {
 
         packet::PacketPtr p;
         const status::StatusCode code = repair_queue_.read(p);
-        roc_panic_if_msg(code != status::StatusOK, "failed to read repair packet: %s",
+        roc_panic_if_msg(code != status::StatusOK,
+                         "failed to read repair packet: status=%s",
                          status::code_to_str(code));
         n_dropped++;
     }

--- a/src/internal_modules/roc_status/code_to_str.cpp
+++ b/src/internal_modules/roc_status/code_to_str.cpp
@@ -16,14 +16,12 @@ const char* code_to_str(StatusCode code) {
     case StatusOK:
         return "OK";
     case StatusUnknown:
-        return "unknown status";
+        return "Unknown";
     case StatusNoData:
-        return "no data";
-    default:
-        break;
+        return "NoData";
     }
 
-    return "invalid status code";
+    return "<invalid>";
 }
 
 } // namespace status

--- a/src/internal_modules/roc_status/code_to_str.h
+++ b/src/internal_modules/roc_status/code_to_str.h
@@ -17,7 +17,7 @@
 namespace roc {
 namespace status {
 
-//! Get human-readable message for status code.
+//! Get string name of status code.
 const char* code_to_str(StatusCode code);
 
 } // namespace status

--- a/src/public_api/src/sender_encoder.cpp
+++ b/src/public_api/src/sender_encoder.cpp
@@ -202,7 +202,7 @@ int roc_sender_encoder_pop(roc_sender_encoder* encoder,
         // TODO: forward status code to user (gh-183)
         if (code != status::StatusNoData) {
             roc_log(LogError,
-                    "roc_sender_encoder_pop(): can't read packet from encoder: %s",
+                    "roc_sender_encoder_pop(): can't read packet from encoder: status=%s",
                     status::code_to_str(code));
         }
         return -1;


### PR DESCRIPTION
#303

Rework code_to_str() to return status name (like "NoData") instead of freeform text (like "no data").

I think returning text will introduce unnecessary difficulties when debugging because you'll have to remember mapping of that text to statuses, but what you actually need to know is always status code itself.