### PR TITLE
Put receiver dropped packets into ring buffer

### DIFF
--- a/src/internal_modules/roc_pipeline/config.cpp
+++ b/src/internal_modules/roc_pipeline/config.cpp
@@ -96,7 +96,7 @@ bool ReceiverSessionConfig::deduce_defaults(audio::ProcessorMap& processor_map) 
         return false;
     }
 
-    if(!prebuf_len) {
+    if (!prebuf_len) {
         prebuf_len = latency.target_latency;
     }
 

--- a/src/internal_modules/roc_pipeline/config.cpp
+++ b/src/internal_modules/roc_pipeline/config.cpp
@@ -66,7 +66,8 @@ bool ReceiverCommonConfig::deduce_defaults(audio::ProcessorMap& processor_map) {
 // ReceiverSessionConfig
 
 ReceiverSessionConfig::ReceiverSessionConfig()
-    : payload_type(0) {
+    : payload_type(0)
+    , prebuf_len(0) {
 }
 
 bool ReceiverSessionConfig::deduce_defaults(audio::ProcessorMap& processor_map) {
@@ -95,12 +96,17 @@ bool ReceiverSessionConfig::deduce_defaults(audio::ProcessorMap& processor_map) 
         return false;
     }
 
+    if(!prebuf_len) {
+        prebuf_len = latency.target_latency;
+    }
+
     return true;
 }
 
 // ReceiverSourceConfig
 
-ReceiverSourceConfig::ReceiverSourceConfig() {
+ReceiverSourceConfig::ReceiverSourceConfig()
+    : max_session_packets(0) {
 }
 
 bool ReceiverSourceConfig::deduce_defaults(audio::ProcessorMap& processor_map) {

--- a/src/internal_modules/roc_pipeline/config.h
+++ b/src/internal_modules/roc_pipeline/config.h
@@ -186,6 +186,9 @@ struct ReceiverSessionConfig {
     //! Watchdog parameters.
     audio::WatchdogConfig watchdog;
 
+    //! Packet prebuffer length, nanoseconds.
+    core::nanoseconds_t prebuf_len;
+
     //! Initialize config.
     ReceiverSessionConfig();
 
@@ -204,6 +207,9 @@ struct ReceiverSourceConfig {
 
     //! Default parameters for a session.
     ReceiverSessionConfig session_defaults;
+
+    //! Maximum number of packets per session.
+    size_t max_session_packets;
 
     //! Initialize config.
     ReceiverSourceConfig();

--- a/src/internal_modules/roc_pipeline/receiver_session_group.h
+++ b/src/internal_modules/roc_pipeline/receiver_session_group.h
@@ -19,6 +19,7 @@
 #include "roc_core/list.h"
 #include "roc_core/noncopyable.h"
 #include "roc_dbgio/csv_dumper.h"
+#include "roc_packet/packet.h"
 #include "roc_packet/packet_factory.h"
 #include "roc_pipeline/metrics.h"
 #include "roc_pipeline/receiver_endpoint.h"
@@ -131,6 +132,8 @@ private:
     status::StatusCode route_transport_packet_(const packet::PacketPtr& packet);
     status::StatusCode route_control_packet_(const packet::PacketPtr& packet,
                                              core::nanoseconds_t current_time);
+    void enqueue_prebuf_packet_(const packet::PacketPtr& packet);
+    void dequeue_prebuf_packet_(ReceiverSession& sess);
 
     bool can_create_session_(const packet::PacketPtr& packet);
 
@@ -164,6 +167,8 @@ private:
     ReceiverSessionRouter session_router_;
 
     dbgio::CsvDumper* dumper_;
+
+    core::List<packet::Packet> prebuf_packets_;
 
     status::StatusCode init_status_;
 };

--- a/src/public_api/include/roc/config.h
+++ b/src/public_api/include/roc/config.h
@@ -1090,6 +1090,14 @@ typedef struct roc_receiver_config {
      * If zero, default value is used. If negative, the check is disabled.
      */
     long long choppy_playback_timeout;
+
+    /** Packet prebuffer length, in nanoseconds.
+     * Packets received for sessions that have not yet been created
+     * will be buffered. Any packets older than the prebuf_len
+     * will be discarded.
+     * If zero, default value is used.
+     */
+    unsigned long long prebuf_len;
 } roc_receiver_config;
 
 /** Interface configuration.

--- a/src/tests/roc_pipeline/test_receiver_source.cpp
+++ b/src/tests/roc_pipeline/test_receiver_source.cpp
@@ -3403,6 +3403,10 @@ TEST(receiver_source, timestamp_mapping_remixing) {
 }
 
 TEST(receiver_source, packet_buffer) {
+    if (!fec_supported()) {
+        TEST_SKIP();
+    }
+
     init_with_defaults();
 
     ReceiverSource receiver(make_default_config(), processor_map, encoding_map,
@@ -3425,7 +3429,7 @@ TEST(receiver_source, packet_buffer) {
     test::PacketWriter packet_writer(arena, *source_endpoint_writer,
                                      *repair_endpoint_writer, encoding_map,
                                      packet_factory, src_id1, src_addr1, dst_addr1,
-                                     dst_addr2, PayloadType_Ch2, fec_scheme, fec_config);
+                                     dst_addr2, PayloadType_Ch1, fec_scheme, fec_config);
 
     // setup reader
     test::FrameReader frame_reader(receiver, frame_factory);

--- a/src/tests/roc_pipeline/test_receiver_source.cpp
+++ b/src/tests/roc_pipeline/test_receiver_source.cpp
@@ -6,6 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "roc_core/log.h"
+#include "roc_fec/block_writer.h"
 #include "test_harness.h"
 #include "test_helpers/control_reader.h"
 #include "test_helpers/control_writer.h"
@@ -20,6 +22,7 @@
 #include "roc_pipeline/receiver_source.h"
 #include "roc_rtp/encoding_map.h"
 #include "roc_stat/mov_min_max.h"
+#include <CppUTest/UtestMacros.h>
 
 // This file contains tests for ReceiverSource. ReceiverSource can be seen as a big
 // composite processor (consisting of chained smaller processors) that transforms
@@ -3400,18 +3403,7 @@ TEST(receiver_source, timestamp_mapping_remixing) {
 }
 
 TEST(receiver_source, packet_buffer) {
-    enum {
-        OutputRate = 48000,
-        PacketRate = 44100,
-        OutputChans = Chans_Stereo,
-        PacketChans = Chans_Mono
-    };
-
-    const audio::PcmSubformat OutputFormat = Format_S16_Ne;
-    const audio::PcmSubformat PacketFormat = Format_S16_Be;
-
-    init_with_specs(OutputRate, OutputChans, OutputFormat, PacketRate, PacketChans,
-                    PacketFormat);
+    init_with_defaults();
 
     ReceiverSource receiver(make_default_config(), processor_map, encoding_map,
                             packet_pool, packet_buffer_pool, frame_pool,
@@ -3419,45 +3411,29 @@ TEST(receiver_source, packet_buffer) {
     LONGS_EQUAL(status::StatusOK, receiver.init_status());
 
     ReceiverSlot* slot = create_slot(receiver);
-    CHECK(slot);
 
-    packet::FifoQueue queue;
     packet::FifoQueue source_queue;
     packet::FifoQueue repair_queue;
 
     packet::IWriter* source_endpoint_writer = create_transport_endpoint(
         slot, address::Iface_AudioSource, address::Proto_RTP_RS8M_Source, dst_addr1);
 
-    packet::IWriter* repair_endpoint_writer = create_transport_endpoint(
-        slot, address::Iface_AudioRepair, address::Proto_RS8M_Repair, dst_addr2);
+    packet::IWriter* repair_endpoint_writer =
+        create_control_endpoint(slot, address::Iface_AudioRepair,
+                                address::Proto_RS8M_Repair, dst_addr2, repair_queue);
 
-    fec::BlockWriterConfig fec_config;
-
-    test::PacketWriter packet_writer(
-        arena, *source_endpoint_writer, *repair_endpoint_writer, encoding_map,
-        packet_factory, src_id1, src_addr1, dst_addr1, dst_addr2, PayloadType_Ch2,
-        packet::FEC_ReedSolomon_M8, fec_config);
+    test::PacketWriter packet_writer(arena, *source_endpoint_writer,
+                                     *repair_endpoint_writer, encoding_map,
+                                     packet_factory, src_id1, src_addr1, dst_addr1,
+                                     dst_addr2, PayloadType_Ch2, fec_scheme, fec_config);
 
     // setup reader
     test::FrameReader frame_reader(receiver, frame_factory);
 
-    packet_writer.write_packets(fec_config.n_source_packets, SamplesPerPacket,
-                                output_sample_spec);
+    packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket,
+                                packet_sample_spec);
 
-    for (int i = 0; i < ManyPackets; ++i) {
-        packet::PacketPtr pp;
-        LONGS_EQUAL(status::StatusOK, queue.read(pp, packet::ModeFetch));
-        CHECK(pp);
-
-        if (pp->flags() & packet::Packet::FlagAudio) {
-            UNSIGNED_LONGS_EQUAL(status::StatusOK, source_queue.write(pp));
-        }
-        if (pp->flags() & packet::Packet::FlagRepair) {
-            UNSIGNED_LONGS_EQUAL(status::StatusOK, repair_queue.write(pp));
-        }
-    }
-
-    LONGS_EQUAL(status::StatusOK, receiver.refresh(frame_reader.refresh_ts(), NULL));
+    refresh_source(receiver, frame_reader.refresh_ts());
     frame_reader.read_nonzero_samples(SamplesPerFrame, output_sample_spec);
     UNSIGNED_LONGS_EQUAL(1, receiver.num_sessions());
 }

--- a/src/tools/roc_recv/cmdline.ggo
+++ b/src/tools/roc_recv/cmdline.ggo
@@ -76,6 +76,8 @@ section "Timeout options"
 
     option "no-play-timeout" - "No-playback timeout, TIME units"
         typestr="TIME" string optional
+    option "prebuf-len" - "Length of packet prebuffer, TIME units"
+        string optional
     option "choppy-play-timeout" - "Choppy playback timeout, TIME units"
         typestr="TIME" string optional
 

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -8,7 +8,6 @@
 
 #include "roc_address/io_uri.h"
 #include "roc_address/network_uri.h"
-#include "roc_address/protocol_map.h"
 #include "roc_core/crash_handler.h"
 #include "roc_core/heap_arena.h"
 #include "roc_core/log.h"
@@ -314,9 +313,8 @@ bool build_receiver_config(const gengetopt_args_info& args,
     }
 
     if (args.prebuf_len_given) {
-        if (!core::parse_duration(
-                args.prebuf_len_arg, 
-                receiver_config.session_defaults.prebuf_len)) {
+        if (!core::parse_duration(args.prebuf_len_arg,
+                                  receiver_config.session_defaults.prebuf_len)) {
             roc_log(LogError, "invalid --prebuf-len: bad format");
             return false;
         }

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -313,6 +313,19 @@ bool build_receiver_config(const gengetopt_args_info& args,
         }
     }
 
+    if (args.prebuf_len_given) {
+        if (!core::parse_duration(
+                args.prebuf_len_arg, 
+                receiver_config.session_defaults.prebuf_len)) {
+            roc_log(LogError, "invalid --prebuf-len: bad format");
+            return false;
+        }
+        if (receiver_config.session_defaults.prebuf_len) {
+            roc_log(LogError, "invalid --prebuf-len: should be > 0");
+            return false;
+        }
+    }
+
     if (args.choppy_play_timeout_given) {
         if (!core::parse_duration(
                 args.choppy_play_timeout_arg,


### PR DESCRIPTION
PR for #217

Added ring buffer for dropped packets, and pass them into new receiver session as they are created.

Added --max-session-packets and --max-sessions arguments to help determine maximum size for ring buffer.