### PR TITLE
Heap arena ownership guard

### DIFF
--- a/src/internal_modules/roc_core/heap_arena.h
+++ b/src/internal_modules/roc_core/heap_arena.h
@@ -66,6 +66,8 @@ public:
 private:
     struct ChunkHeader {
         size_t size;
+        //! The heap arena that the chunk belongs to.
+        HeapArena* owner;
         AlignMax data[];
     };
 

--- a/src/tests/roc_core/test_heap_arena.cpp
+++ b/src/tests/roc_core/test_heap_arena.cpp
@@ -70,5 +70,19 @@ TEST(heap_arena, guard_object_violations) {
     CHECK(arena.num_guard_failures() == 2);
 }
 
+TEST(heap_arena, ownership_guard) {
+    HeapArena arena0;
+    HeapArena arena1;
+
+    void* pointer = arena0.allocate(128);
+    CHECK(pointer);
+
+    arena1.deallocate(pointer);
+    CHECK(arena1.num_guard_failures() == 1);
+
+    arena0.deallocate(pointer);
+    CHECK(arena0.num_guard_failures() == 0);
+}
+
 } // namespace core
 } // namespace roc


### PR DESCRIPTION
# Why

For https://github.com/roc-streaming/roc-toolkit/issues/583

# What

* Added owner pointer field to ChunkHeader.
* Set it in allocate, check in deallocate.
* Moved the num_allocations checking in deallocate, before freeing.
* Wrote test.

# Testing

There are tests.