### PR TITLE
AlignOps EndianOps cpp files

### DIFF
--- a/src/internal_modules/roc_core/align_ops.cpp
+++ b/src/internal_modules/roc_core/align_ops.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_core/align_ops.h"
+
+namespace roc {
+namespace core {
+
+size_t AlignOps::max_alignment() {
+    return sizeof(AlignMax);
+}
+
+size_t AlignOps::align_max(size_t size) {
+    return align_as(size, max_alignment());
+}
+
+size_t AlignOps::align_as(size_t size, size_t alignment) {
+    if (alignment == 0) {
+        return size;
+    }
+
+    if (size % alignment != 0) {
+        size += alignment - size % alignment;
+    }
+
+    return size;
+}
+
+size_t AlignOps::pad_max(size_t size) {
+    return pad_as(size, max_alignment());
+}
+
+size_t AlignOps::pad_as(size_t size, size_t alignment) {
+    if (alignment == 0) {
+        return 0;
+    }
+
+    size_t new_size = size / alignment * alignment;
+    if (new_size < size) {
+        new_size += alignment;
+    }
+
+    return (new_size - size);
+}
+
+} // namespace core
+} // namespace roc

--- a/src/internal_modules/roc_core/align_ops.h
+++ b/src/internal_modules/roc_core/align_ops.h
@@ -7,7 +7,7 @@
  */
 
 //! @file roc_core/align_ops.h
-//! @brief TODO.
+//! @brief Alignment operations.
 
 #ifndef ROC_CORE_ALIGN_OPS_H_
 #define ROC_CORE_ALIGN_OPS_H_

--- a/src/internal_modules/roc_core/align_ops.h
+++ b/src/internal_modules/roc_core/align_ops.h
@@ -7,7 +7,7 @@
  */
 
 //! @file roc_core/align_ops.h
-//! @brief Alignment operations.
+//! @brief TODO.
 
 #ifndef ROC_CORE_ALIGN_OPS_H_
 #define ROC_CORE_ALIGN_OPS_H_
@@ -28,46 +28,19 @@ union AlignMax {
 class AlignOps {
 public:
     //! Get maximum alignment for current platform.
-    static inline size_t max_alignment() {
-        return sizeof(AlignMax);
-    }
+    static size_t max_alignment();
 
     //! Return size aligned to maximum alignment.
-    static inline size_t align_max(size_t size) {
-        return align_as(size, max_alignment());
-    }
+    static size_t align_max(size_t size);
 
     //! Return size aligned to given alignment.
-    static inline size_t align_as(size_t size, size_t alignment) {
-        if (alignment == 0) {
-            return size;
-        }
-
-        if (size % alignment != 0) {
-            size += alignment - size % alignment;
-        }
-
-        return size;
-    }
+    static size_t align_as(size_t size, size_t alignment);
 
     //! Return padding needed for maximum alignment.
-    static inline size_t pad_max(size_t size) {
-        return pad_as(size, max_alignment());
-    }
+    static size_t pad_max(size_t size);
 
     //! Return padding needed for given alignment.
-    static inline size_t pad_as(size_t size, size_t alignment) {
-        if (alignment == 0) {
-            return 0;
-        }
-
-        size_t new_size = size / alignment * alignment;
-        if (new_size < size) {
-            new_size += alignment;
-        }
-
-        return (new_size - size);
-    }
+    static size_t pad_as(size_t size, size_t alignment);
 };
 
 } // namespace core

--- a/src/internal_modules/roc_core/endian_ops.cpp
+++ b/src/internal_modules/roc_core/endian_ops.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_core/endian_ops.h"
+
+namespace roc {
+namespace core {
+
+uint8_t EndianOps::reverse_octets_(uint8_t v) {
+    return v;
+}
+
+int8_t EndianOps::reverse_octets_(int8_t v) {
+    return v;
+}
+
+uint16_t EndianOps::reverse_octets_(uint16_t v) {
+    return uint16_t(uint16_t(v >> 8) & 0xffu) | uint16_t((v & 0xffu) << 8);
+}
+
+int16_t EndianOps::reverse_octets_(int16_t v) {
+    return (int16_t)reverse_octets_((uint16_t)v);
+}
+
+uint32_t EndianOps::reverse_octets_(uint32_t v) {
+    return (((v & 0xff000000u) >> 24) | ((v & 0x00ff0000u) >> 8)
+            | ((v & 0x0000ff00u) << 8) | ((v & 0x000000ffu) << 24));
+}
+
+int32_t EndianOps::reverse_octets_(int32_t v) {
+    return (int32_t)reverse_octets_((uint32_t)v);
+}
+
+uint64_t EndianOps::reverse_octets_(uint64_t v) {
+    return ((v & 0xff00000000000000ull) >> 56) | ((v & 0x00ff000000000000ull) >> 40)
+        | ((v & 0x0000ff0000000000ull) >> 24) | ((v & 0x000000ff00000000ull) >> 8)
+        | ((v & 0x00000000ff000000ull) << 8) | ((v & 0x0000000000ff0000ull) << 24)
+        | ((v & 0x000000000000ff00ull) << 40) | ((v & 0x00000000000000ffull) << 56);
+}
+
+int64_t EndianOps::reverse_octets_(int64_t v) {
+    return (int64_t)reverse_octets_((uint64_t)v);
+}
+
+float EndianOps::reverse_octets_(float v) {
+    union {
+        float f;
+        uint32_t i;
+    } u;
+
+    u.f = v;
+    u.i = reverse_octets_(u.i);
+
+    return u.f;
+}
+
+double EndianOps::reverse_octets_(double v) {
+    union {
+        double f;
+        uint64_t i;
+    } u;
+
+    u.f = v;
+    u.i = reverse_octets_(u.i);
+
+    return u.f;
+}
+
+} // namespace core
+} // namespace roc

--- a/src/internal_modules/roc_core/endian_ops.h
+++ b/src/internal_modules/roc_core/endian_ops.h
@@ -51,65 +51,16 @@ public:
 #endif
 
 private:
-    static inline uint8_t reverse_octets_(uint8_t v) {
-        return v;
-    }
-
-    static inline int8_t reverse_octets_(int8_t v) {
-        return v;
-    }
-
-    static inline uint16_t reverse_octets_(uint16_t v) {
-        return uint16_t(uint16_t(v >> 8) & 0xffu) | uint16_t((v & 0xffu) << 8);
-    }
-
-    static inline int16_t reverse_octets_(int16_t v) {
-        return (int16_t)reverse_octets_((uint16_t)v);
-    }
-
-    static inline uint32_t reverse_octets_(uint32_t v) {
-        return (((v & 0xff000000u) >> 24) | ((v & 0x00ff0000u) >> 8)
-                | ((v & 0x0000ff00u) << 8) | ((v & 0x000000ffu) << 24));
-    }
-
-    static inline int32_t reverse_octets_(int32_t v) {
-        return (int32_t)reverse_octets_((uint32_t)v);
-    }
-
-    static inline uint64_t reverse_octets_(uint64_t v) {
-        return ((v & 0xff00000000000000ull) >> 56) | ((v & 0x00ff000000000000ull) >> 40)
-            | ((v & 0x0000ff0000000000ull) >> 24) | ((v & 0x000000ff00000000ull) >> 8)
-            | ((v & 0x00000000ff000000ull) << 8) | ((v & 0x0000000000ff0000ull) << 24)
-            | ((v & 0x000000000000ff00ull) << 40) | ((v & 0x00000000000000ffull) << 56);
-    }
-
-    static inline int64_t reverse_octets_(int64_t v) {
-        return (int64_t)reverse_octets_((uint64_t)v);
-    }
-
-    static inline float reverse_octets_(float v) {
-        union {
-            float f;
-            uint32_t i;
-        } u;
-
-        u.f = v;
-        u.i = reverse_octets_(u.i);
-
-        return u.f;
-    }
-
-    static inline double reverse_octets_(double v) {
-        union {
-            double f;
-            uint64_t i;
-        } u;
-
-        u.f = v;
-        u.i = reverse_octets_(u.i);
-
-        return u.f;
-    }
+    static uint8_t reverse_octets_(uint8_t v);
+    static int8_t reverse_octets_(int8_t v);
+    static uint16_t reverse_octets_(uint16_t v);
+    static int16_t reverse_octets_(int16_t v);
+    static uint32_t reverse_octets_(uint32_t v);
+    static int32_t reverse_octets_(int32_t v);
+    static uint64_t reverse_octets_(uint64_t v);
+    static int64_t reverse_octets_(int64_t v);
+    static float reverse_octets_(float v);
+    static double reverse_octets_(double v);
 };
 
 } // namespace core


### PR DESCRIPTION
# Why

For https://github.com/roc-streaming/roc-toolkit/issues/601

# What

* Moved non-template methods to cpp files.
* Removed inline as a result.

# Testing

There are tests.