### PR TITLE
Follow up for #549 

### DIFF
--- a/src/tests/roc_audio/test_depacketizer.cpp
+++ b/src/tests/roc_audio/test_depacketizer.cpp
@@ -711,5 +711,28 @@ TEST(depacketizer, read_after_error) {
     }
 }
 
+TEST(depacketizer, timestamp_fract_frame_per_packet) {
+    enum {
+        StartTimestamp = 1000,
+        NumPackets = 3,
+        SamplesPerFrame = SamplesPerPacket + 50
+    };
+
+    PcmEncoder encoder(PcmFmt, SampleSpecs);
+    PcmDecoder decoder(PcmFmt, SampleSpecs);
+
+    packet::Queue queue;
+    Depacketizer dp(queue, decoder, SampleSpecs, false);
+    CHECK(dp.is_valid());
+
+    core::nanoseconds_t capt_ts =
+        Now + SampleSpecs.samples_overall_2_ns(SamplesPerPacket);
+    // 1st packet in the frame has 0 capture ts, and the next
+    queue.write(new_packet(encoder, StartTimestamp, 0.1f, 0));
+    queue.write(
+        new_packet(encoder, StartTimestamp + SamplesPerPacket / NumCh, 0.1f, capt_ts));
+    expect_output(dp, SamplesPerFrame, 0.1f, Now);
+}
+
 } // namespace audio
 } // namespace roc

--- a/src/tests/roc_audio/test_depacketizer.cpp
+++ b/src/tests/roc_audio/test_depacketizer.cpp
@@ -728,9 +728,11 @@ TEST(depacketizer, timestamp_fract_frame_per_packet) {
     core::nanoseconds_t capt_ts =
         Now + SampleSpecs.samples_overall_2_ns(SamplesPerPacket);
     // 1st packet in the frame has 0 capture ts, and the next
-    queue.write(new_packet(encoder, StartTimestamp, 0.1f, 0));
-    queue.write(
-        new_packet(encoder, StartTimestamp + SamplesPerPacket / NumCh, 0.1f, capt_ts));
+    CHECK_EQUAL(status::StatusOK,
+                queue.write(new_packet(encoder, StartTimestamp, 0.1f, 0)));
+    CHECK_EQUAL(status::StatusOK,
+                queue.write(new_packet(encoder, StartTimestamp + SamplesPerPacket / NumCh,
+                                       0.1f, capt_ts)));
     expect_output(dp, SamplesPerFrame, 0.1f, Now);
 }
 

--- a/src/tests/roc_pipeline/test_helpers/frame_reader.h
+++ b/src/tests/roc_pipeline/test_helpers/frame_reader.h
@@ -132,8 +132,8 @@ private:
             const core::nanoseconds_t capture_ts =
                 base_ts + sample_spec.samples_per_chan_2_ns(abs_offset_);
 
-            expect_capture_timestamp(capture_ts, frame.capture_timestamp(),
-                                     TimestampEpsilon);
+            expect_capture_timestamp(capture_ts, frame.capture_timestamp(), sample_spec,
+                                     TimestampEpsilonSmpls);
         }
     }
 

--- a/src/tests/roc_pipeline/test_helpers/packet_reader.h
+++ b/src/tests/roc_pipeline/test_helpers/packet_reader.h
@@ -186,7 +186,7 @@ private:
                 base_ts + sample_spec.samples_per_chan_2_ns(abs_offset_);
 
             expect_capture_timestamp(capture_ts, pkt.rtp()->capture_timestamp,
-                                     TimestampEpsilon);
+                                     sample_spec, TimestampEpsilonSmpls);
         }
     }
 

--- a/src/tests/roc_pipeline/test_helpers/packet_reader.h
+++ b/src/tests/roc_pipeline/test_helpers/packet_reader.h
@@ -51,7 +51,7 @@ public:
 
     void read_packet(size_t samples_per_packet,
                      const audio::SampleSpec& sample_spec,
-                     core::nanoseconds_t base_capture_ts = 0) {
+                     core::nanoseconds_t base_capture_ts = -1) {
         packet::PacketPtr pp = read_packet_();
 
         audio::sample_t samples[MaxSamples] = {};
@@ -69,9 +69,9 @@ public:
         abs_offset_ += samples_per_packet;
     }
 
-    packet::PacketPtr read_nonzero_packet(size_t samples_per_packet,
-                                          const audio::SampleSpec& sample_spec,
-                                          core::nanoseconds_t base_capture_ts = 0) {
+    void read_nonzero_packet(size_t samples_per_packet,
+                             const audio::SampleSpec& sample_spec,
+                             core::nanoseconds_t base_capture_ts = -1) {
         packet::PacketPtr pp = read_packet_();
 
         audio::sample_t samples[MaxSamples] = {};
@@ -86,13 +86,11 @@ public:
         }
         CHECK(non_zero > 0);
         abs_offset_ += samples_per_packet;
-
-        return pp;
     }
 
     void read_zero_packet(size_t samples_per_packet,
                           const audio::SampleSpec& sample_spec,
-                          core::nanoseconds_t base_capture_ts = 0) {
+                          core::nanoseconds_t base_capture_ts = -1) {
         packet::PacketPtr pp = read_packet_();
 
         audio::sample_t samples[MaxSamples] = {};
@@ -179,7 +177,7 @@ private:
                                   core::nanoseconds_t base_ts) {
         CHECK(pkt.rtp());
 
-        if (base_ts == 0) {
+        if (base_ts < 0) {
             LONGS_EQUAL(0, pkt.rtp()->capture_timestamp);
         } else {
             const core::nanoseconds_t capture_ts =

--- a/src/tests/roc_pipeline/test_helpers/packet_reader.h
+++ b/src/tests/roc_pipeline/test_helpers/packet_reader.h
@@ -51,7 +51,7 @@ public:
 
     void read_packet(size_t samples_per_packet,
                      const audio::SampleSpec& sample_spec,
-                     core::nanoseconds_t base_capture_ts = -1) {
+                     core::nanoseconds_t base_capture_ts = 0) {
         packet::PacketPtr pp = read_packet_();
 
         audio::sample_t samples[MaxSamples] = {};
@@ -69,9 +69,9 @@ public:
         abs_offset_ += samples_per_packet;
     }
 
-    void read_nonzero_packet(size_t samples_per_packet,
-                             const audio::SampleSpec& sample_spec,
-                             core::nanoseconds_t base_capture_ts = -1) {
+    packet::PacketPtr read_nonzero_packet(size_t samples_per_packet,
+                                          const audio::SampleSpec& sample_spec,
+                                          core::nanoseconds_t base_capture_ts = 0) {
         packet::PacketPtr pp = read_packet_();
 
         audio::sample_t samples[MaxSamples] = {};
@@ -86,11 +86,13 @@ public:
         }
         CHECK(non_zero > 0);
         abs_offset_ += samples_per_packet;
+
+        return pp;
     }
 
     void read_zero_packet(size_t samples_per_packet,
                           const audio::SampleSpec& sample_spec,
-                          core::nanoseconds_t base_capture_ts = -1) {
+                          core::nanoseconds_t base_capture_ts = 0) {
         packet::PacketPtr pp = read_packet_();
 
         audio::sample_t samples[MaxSamples] = {};
@@ -177,7 +179,7 @@ private:
                                   core::nanoseconds_t base_ts) {
         CHECK(pkt.rtp());
 
-        if (base_ts < 0) {
+        if (base_ts == 0) {
             LONGS_EQUAL(0, pkt.rtp()->capture_timestamp);
         } else {
             const core::nanoseconds_t capture_ts =

--- a/src/tests/roc_pipeline/test_helpers/utils.h
+++ b/src/tests/roc_pipeline/test_helpers/utils.h
@@ -13,9 +13,9 @@
 
 #include "roc_address/socket_addr.h"
 #include "roc_audio/sample.h"
+#include "roc_audio/sample_spec.h"
 #include "roc_core/stddefs.h"
 #include "roc_core/time.h"
-#include "roc_pipeline/config.h"
 
 namespace roc {
 namespace pipeline {

--- a/src/tests/roc_pipeline/test_helpers/utils.h
+++ b/src/tests/roc_pipeline/test_helpers/utils.h
@@ -15,6 +15,7 @@
 #include "roc_audio/sample.h"
 #include "roc_core/stddefs.h"
 #include "roc_core/time.h"
+#include "roc_pipeline/config.h"
 
 namespace roc {
 namespace pipeline {
@@ -24,7 +25,8 @@ namespace {
 
 const double SampleEpsilon = 0.00001;
 
-const core::nanoseconds_t TimestampEpsilon = core::Microsecond;
+const core::nanoseconds_t TimestampEpsilon =
+    (core::nanoseconds_t)(1. / DefaultSampleRate * core::Second);
 
 inline audio::sample_t nth_sample(uint8_t n) {
     return audio::sample_t(n) / 1024;

--- a/src/tests/roc_pipeline/test_helpers/utils.h
+++ b/src/tests/roc_pipeline/test_helpers/utils.h
@@ -25,8 +25,7 @@ namespace {
 
 const double SampleEpsilon = 0.00001;
 
-const core::nanoseconds_t TimestampEpsilon =
-    (core::nanoseconds_t)(1. / DefaultSampleRate * core::Second);
+const size_t TimestampEpsilonSmpls = 1;
 
 inline audio::sample_t nth_sample(uint8_t n) {
     return audio::sample_t(n) / 1024;
@@ -40,7 +39,10 @@ inline address::SocketAddr new_address(int port) {
 
 inline void expect_capture_timestamp(core::nanoseconds_t expected,
                                      core::nanoseconds_t actual,
-                                     core::nanoseconds_t epsilon) {
+                                     const audio::SampleSpec& sample_spec,
+                                     const size_t epsilon_smpls) {
+    const core::nanoseconds_t epsilon = sample_spec.samples_per_chan_2_ns(epsilon_smpls);
+
     if (!core::ns_equal_delta(expected, actual, epsilon)) {
         char sbuff[256];
         snprintf(sbuff, sizeof(sbuff),

--- a/src/tests/roc_pipeline/test_loopback_sink_2_source.cpp
+++ b/src/tests/roc_pipeline/test_loopback_sink_2_source.cpp
@@ -374,21 +374,21 @@ void send_receive(int flags,
 
 } // namespace
 
-TEST_GROUP(sender_sink_receiver_source) {};
+TEST_GROUP(loopback_sink_2_source) {};
 
-TEST(sender_sink_receiver_source, bare_rtp) {
+TEST(loopback_sink_2_source, bare_rtp) {
     enum { Chans = Chans_Stereo, NumSess = 1 };
 
     send_receive(FlagNone, NumSess, Chans, Chans);
 }
 
-TEST(sender_sink_receiver_source, interleaving) {
+TEST(loopback_sink_2_source, interleaving) {
     enum { Chans = Chans_Stereo, NumSess = 1 };
 
     send_receive(FlagInterleaving, NumSess, Chans, Chans);
 }
 
-TEST(sender_sink_receiver_source, fec_rs) {
+TEST(loopback_sink_2_source, fec_rs) {
     enum { Chans = Chans_Stereo, NumSess = 1 };
 
     if (is_fec_supported(FlagReedSolomon)) {
@@ -396,7 +396,7 @@ TEST(sender_sink_receiver_source, fec_rs) {
     }
 }
 
-TEST(sender_sink_receiver_source, fec_ldpc) {
+TEST(loopback_sink_2_source, fec_ldpc) {
     enum { Chans = Chans_Stereo, NumSess = 1 };
 
     if (is_fec_supported(FlagLDPC)) {
@@ -404,7 +404,7 @@ TEST(sender_sink_receiver_source, fec_ldpc) {
     }
 }
 
-TEST(sender_sink_receiver_source, fec_interleaving) {
+TEST(loopback_sink_2_source, fec_interleaving) {
     enum { Chans = Chans_Stereo, NumSess = 1 };
 
     if (is_fec_supported(FlagReedSolomon)) {
@@ -412,7 +412,7 @@ TEST(sender_sink_receiver_source, fec_interleaving) {
     }
 }
 
-TEST(sender_sink_receiver_source, fec_loss) {
+TEST(loopback_sink_2_source, fec_loss) {
     enum { Chans = Chans_Stereo, NumSess = 1 };
 
     if (is_fec_supported(FlagReedSolomon)) {
@@ -420,7 +420,7 @@ TEST(sender_sink_receiver_source, fec_loss) {
     }
 }
 
-TEST(sender_sink_receiver_source, fec_drop_source) {
+TEST(loopback_sink_2_source, fec_drop_source) {
     enum { Chans = Chans_Stereo, NumSess = 0 };
 
     if (is_fec_supported(FlagReedSolomon)) {
@@ -428,7 +428,7 @@ TEST(sender_sink_receiver_source, fec_drop_source) {
     }
 }
 
-TEST(sender_sink_receiver_source, fec_drop_repair) {
+TEST(loopback_sink_2_source, fec_drop_repair) {
     enum { Chans = Chans_Stereo, NumSess = 1 };
 
     if (is_fec_supported(FlagReedSolomon)) {
@@ -436,25 +436,25 @@ TEST(sender_sink_receiver_source, fec_drop_repair) {
     }
 }
 
-TEST(sender_sink_receiver_source, channel_mapping_stereo_to_mono) {
+TEST(loopback_sink_2_source, channel_mapping_stereo_to_mono) {
     enum { FrameChans = Chans_Stereo, PacketChans = Chans_Mono, NumSess = 1 };
 
     send_receive(FlagNone, NumSess, FrameChans, PacketChans);
 }
 
-TEST(sender_sink_receiver_source, channel_mapping_mono_to_stereo) {
+TEST(loopback_sink_2_source, channel_mapping_mono_to_stereo) {
     enum { FrameChans = Chans_Mono, PacketChans = Chans_Stereo, NumSess = 1 };
 
     send_receive(FlagNone, NumSess, FrameChans, PacketChans);
 }
 
-TEST(sender_sink_receiver_source, timestamp_mapping) {
+TEST(loopback_sink_2_source, timestamp_mapping) {
     enum { Chans = Chans_Stereo, NumSess = 1 };
 
     send_receive(FlagRTCP | FlagCTS, NumSess, Chans, Chans);
 }
 
-TEST(sender_sink_receiver_source, timestamp_mapping_remixing) {
+TEST(loopback_sink_2_source, timestamp_mapping_remixing) {
     enum { FrameChans = Chans_Mono, PacketChans = Chans_Stereo, NumSess = 1 };
 
     send_receive(FlagRTCP | FlagCTS, NumSess, FrameChans, PacketChans);

--- a/src/tests/roc_pipeline/test_receiver_source.cpp
+++ b/src/tests/roc_pipeline/test_receiver_source.cpp
@@ -1774,9 +1774,9 @@ TEST(receiver_source, recv_timestamp_mapping_remixing) {
                 const core::nanoseconds_t expected_capture_ts = first_ts
                     + output_sample_spec.samples_overall_2_ns(frame_num * frame_size);
 
-                test::expect_capture_timestamp(expected_capture_ts,
-                                               frame.capture_timestamp(),
-                                               test::TimestampEpsilon);
+                test::expect_capture_timestamp(
+                    expected_capture_ts, frame.capture_timestamp(), output_sample_spec,
+                    test::TimestampEpsilonSmpls);
 
                 frame_num++;
             }

--- a/src/tests/roc_pipeline/test_receiver_source.cpp
+++ b/src/tests/roc_pipeline/test_receiver_source.cpp
@@ -1707,7 +1707,7 @@ TEST(receiver_source, timestamp_mapping_periodic_control_packets) {
     }
 }
 
-IGNORE_TEST(receiver_source, timestamp_mapping_remixing) {
+TEST(receiver_source, recv_timestamp_mapping_remixing) {
     enum {
         OutputRate = 48000,
         PacketRate = 44100,
@@ -1734,7 +1734,7 @@ IGNORE_TEST(receiver_source, timestamp_mapping_remixing) {
 
     test::PacketWriter packet_writer(arena, *packet_endpoint, encoding_map,
                                      packet_factory, byte_buffer_factory, src1, dst1,
-                                     PayloadType_Ch2);
+                                     PayloadType_Ch1);
 
     test::ControlWriter control_writer(*control_endpoint, packet_factory,
                                        byte_buffer_factory, src1, dst2);

--- a/src/tests/roc_pipeline/test_sender_sink.cpp
+++ b/src/tests/roc_pipeline/test_sender_sink.cpp
@@ -377,7 +377,7 @@ TEST(sender_sink, timestamp_mapping) {
     packet_reader.read_eof();
 }
 
-TEST(sender_sink, timestamp_mapping_remixing_packet_reader) {
+TEST(sender_sink, timestamp_mapping_remixing) {
     enum {
         InputRate = 48000,
         PacketRate = 44100,
@@ -424,6 +424,7 @@ TEST(sender_sink, timestamp_mapping_remixing_packet_reader) {
         if (np == 0) {
             cts = pp->rtp()->capture_timestamp;
             CHECK(cts >= unix_base);
+            CHECK(cts < unix_base + core::Millisecond);
         } else {
             test::expect_capture_timestamp(cts, pp->rtp()->capture_timestamp,
                                            packet_sample_spec,

--- a/src/tests/roc_pipeline/test_sender_sink.cpp
+++ b/src/tests/roc_pipeline/test_sender_sink.cpp
@@ -384,8 +384,6 @@ TEST(sender_sink, timestamp_mapping_remixing_packet_reader) {
         InputChans = Chans_Stereo,
         PacketChans = Chans_Mono
     };
-    const core::nanoseconds_t eps_resampled =
-        core::nanoseconds_t(1.f / PacketRate * core::Second);
 
     init(InputRate, InputChans, PacketRate, PacketChans);
 
@@ -428,7 +426,8 @@ TEST(sender_sink, timestamp_mapping_remixing_packet_reader) {
             CHECK(cts >= unix_base);
         } else {
             test::expect_capture_timestamp(cts, pp->rtp()->capture_timestamp,
-                                           eps_resampled);
+                                           packet_sample_spec,
+                                           test::TimestampEpsilonSmpls);
         }
         cts += packet_sample_spec.samples_per_chan_2_ns(pp->rtp()->duration);
     }


### PR DESCRIPTION
#539 

From #549:

In receiver_source test recv_timestamp_mapping_remixing the failure was caused by the issue in Depacketizer. As you suggested (after my localization): https://github.com/roc-streaming/roc-toolkit/issues/539#issuecomment-1712284093:
 
>   We should check if Depacketizer correctly handles case when first packet for frame had zero CTS, and second packet for the same frame had non-zero CTS.
 
>   I think it's not covered right now.

> We need a test for this and maybe a fix.

In sender_sink tests the issue is simple: Resampler backend throw away first n samples (N==latency), which was not properly reflected in test::PacketReader