### PR TITLE
Add lengths to StringList

### DIFF
--- a/src/internal_modules/roc_core/string_list.cpp
+++ b/src/internal_modules/roc_core/string_list.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "roc_core/string_list.h"
+#include "roc_core/log.h"
 #include "roc_core/panic.h"
 
 namespace roc {
@@ -14,6 +15,7 @@ namespace core {
 
 StringList::StringList(IArena& arena)
     : data_(arena)
+    , front_(NULL)
     , back_(NULL)
     , size_(0) {
 }
@@ -24,7 +26,7 @@ size_t StringList::size() const {
 
 const char* StringList::front() const {
     if (size_) {
-        return &data_[0];
+        return front_->str;
     } else {
         return NULL;
     }
@@ -32,7 +34,7 @@ const char* StringList::front() const {
 
 const char* StringList::back() const {
     if (size_) {
-        return back_;
+        return back_->str;
     } else {
         return NULL;
     }
@@ -54,14 +56,44 @@ const char* StringList::nextof(const char* str) const {
         roc_panic("stringlist: string doesn't belong to the list");
     }
 
-    const char* ptr = str + strlen(str) + 1;
-    roc_panic_if(ptr > end);
+    const Header* str_header = ROC_CONTAINER_OF(const_cast<char*>(str), Header, str);
 
-    if (ptr == end) {
+    if (str_header == back_) {
         return NULL;
     }
 
-    return ptr;
+    const Header* next_header =
+        (const Header*)((const char*)str_header + str_header->len);
+    return next_header->str;
+}
+
+const char* StringList::prevof(const char* str) const {
+    if (str == NULL) {
+        roc_panic("stringlist: string is null");
+    }
+
+    if (size_ == 0) {
+        roc_panic("stringlist: list is empty");
+    }
+
+    const char* begin = &data_[0];
+    const char* end = &data_[0] + data_.size();
+
+    if (str < begin || str >= end) {
+        roc_panic("stringlist: string doesn't belong to the list");
+    }
+
+    const Header* str_header = ROC_CONTAINER_OF(const_cast<char*>(str), Header, str);
+
+    if (str_header == front_) {
+        return NULL;
+    }
+
+    const Footer* prev_footer = (const Footer*)((const char*)str_header - sizeof(Footer));
+    const Header* prev_header =
+        (const Header*)((const char*)str_header - prev_footer->len);
+
+    return prev_header->str;
 }
 
 void StringList::clear() {
@@ -84,7 +116,9 @@ bool StringList::push_back(const char* begin, const char* end) {
     }
 
     const size_t cur_sz = data_.size();
-    const size_t add_sz = (size_t)(end - begin) + 1;
+    const size_t str_sz = (size_t)(end - begin) + 1;
+    const size_t add_sz =
+        sizeof(Header) + AlignOps::align_as(str_sz, sizeof(Header)) + sizeof(Footer);
 
     if (!grow_(cur_sz + add_sz)) {
         return false;
@@ -94,35 +128,69 @@ bool StringList::push_back(const char* begin, const char* end) {
         return false;
     }
 
-    back_ = &data_[cur_sz];
-    memcpy(&data_[cur_sz], begin, add_sz - 1);
-    data_[cur_sz + add_sz - 1] = '\0';
+    front_ = (Header*)(data_.data());
+    back_ = (Header*)(data_.data() + cur_sz);
+
+    Header* str_header = back_;
+    str_header->len = static_cast<uint32_t>(add_sz);
+
+    memcpy(&data_[cur_sz + sizeof(Header)], begin, str_sz - 1); // copy string
+    data_[cur_sz + sizeof(Header) + str_sz - 1] = '\0';         // add null
+
+    Footer* str_footer = (Footer*)(data_.data() + cur_sz + add_sz - sizeof(Footer));
+    str_footer->len = static_cast<uint32_t>(add_sz);
     size_++;
 
     return true;
 }
 
-bool StringList::push_unique(const char* str) {
+// bool StringList::push_unique(const char* str) {
+//     if (str == NULL) {
+//         roc_panic("stringlist: string is null");
+//     }
+
+//     return push_unique(str, str + strlen(str));
+// }
+
+// bool StringList::push_unique(const char* begin, const char* end) {
+//     if (begin == NULL || end == NULL || begin > end) {
+//         roc_panic("stringlist: invalid range");
+//     }
+
+//     for (const char* s = front(); s; s = nextof(s)) {
+//         const size_t s_len = strlen(s);
+//         if (s_len == size_t(end - begin) && memcmp(s, begin, s_len) == 0) {
+//             return true;
+//         }
+//     }
+
+//     return push_back(begin, end);
+// }
+
+const char* StringList::find(const char* str) {
     if (str == NULL) {
         roc_panic("stringlist: string is null");
     }
 
-    return push_unique(str, str + strlen(str));
+    return find(str, str + strlen(str));
 }
 
-bool StringList::push_unique(const char* begin, const char* end) {
+const char* StringList::find(const char* begin, const char* end) {
     if (begin == NULL || end == NULL || begin > end) {
         roc_panic("stringlist: invalid range");
     }
 
+    const size_t str_len = (size_t)(end - begin);
+    const size_t find_sz =
+        sizeof(Header) + AlignOps::align_as(str_len + 1, sizeof(Header)) + sizeof(Footer);
     for (const char* s = front(); s; s = nextof(s)) {
-        const size_t s_len = strlen(s);
-        if (s_len == size_t(end - begin) && memcmp(s, begin, s_len) == 0) {
-            return true;
+        const Header* s_header = ROC_CONTAINER_OF(const_cast<char*>(s), Header, str);
+        if (s_header->len == find_sz && memcmp(s, begin, str_len) == 0) {
+            return s;
         }
     }
 
-    return push_back(begin, end);
+    return NULL;
 }
 
 bool StringList::grow_(size_t new_size) {

--- a/src/internal_modules/roc_core/string_list.h
+++ b/src/internal_modules/roc_core/string_list.h
@@ -44,9 +44,17 @@ public:
     //! @returns
     //!  the first string of the given string or NULL if it is the last string.
     //! @remarks
-    //!  @p str should be a pointer returned by front() or nextof(). These
-    //!  pointers are invalidated by methods that modify the list.
+    //!  @p str should be a pointer returned by front(), nextof(), or prevof().
+    //!  These pointers are invalidated by methods that modify the list.
     const char* nextof(const char* str) const;
+
+    //! Get previous string.
+    //! @returns
+    //!  the last string of the given string or NULL if it is the first string.
+    //! @remarks
+    //!  @p str should be a pointer returned by back(), nextof(), or prevof().
+    //!  These pointers are invalidated by methods that modify the list.
+    const char* prevof(const char* str) const;
 
     //! Clear the list.
     void clear();
@@ -65,27 +73,33 @@ public:
     //!  false if allocation failed.
     ROC_ATTR_NODISCARD bool push_back(const char* str_begin, const char* str_end);
 
-    //! Append string to the list if it's not in the list already.
-    //! @remarks
-    //!  Reallocates memory if necessary.
+    //! Find string in the list.
     //! @returns
-    //!  false if allocation failed.
-    ROC_ATTR_NODISCARD bool push_unique(const char* str);
+    //!  the string in the list or NULL if it is not found.
+    ROC_ATTR_NODISCARD const char* find(const char* str);
 
-    //! Append string from a range to the list if it's not in the list already.
-    //! @remarks
-    //!  Reallocates memory if necessary.
+    //! Find string in the list.
     //! @returns
-    //!  false if allocation failed.
-    ROC_ATTR_NODISCARD bool push_unique(const char* str_begin, const char* str_end);
+    //!  the string in the list or NULL if it is not found.
+    ROC_ATTR_NODISCARD const char* find(const char* str_begin, const char* str_end);
 
 private:
     enum { MinCapacity = 128 };
 
     bool grow_(size_t size);
 
+    struct Header {
+        uint32_t len;
+        char str[];
+    };
+
+    struct Footer {
+        uint32_t len;
+    };
+
     core::Array<char> data_;
-    const char* back_;
+    Header* front_;
+    Header* back_;
     size_t size_;
 };
 

--- a/src/internal_modules/roc_sndio/backend_dispatcher.cpp
+++ b/src/internal_modules/roc_sndio/backend_dispatcher.cpp
@@ -107,7 +107,7 @@ bool BackendDispatcher::get_supported_schemes(core::StringList& result) {
 
         // every device driver has its own scheme
         if (driver_info.type == DriverType_Device) {
-            if (!result.push_unique(driver_info.name)) {
+            if (!result.find(driver_info.name) && !result.push_back(driver_info.name)) {
                 return false;
             }
         }
@@ -128,7 +128,7 @@ bool BackendDispatcher::get_supported_formats(core::StringList& result) {
         const DriverInfo& driver_info = BackendMap::instance().nth_driver(n);
 
         if (driver_info.type == DriverType_File) {
-            if (!result.push_unique(driver_info.name)) {
+            if (!result.find(driver_info.name) && !result.push_back(driver_info.name)) {
                 return false;
             }
         }

--- a/src/tests/roc_core/test_string_list.cpp
+++ b/src/tests/roc_core/test_string_list.cpp
@@ -71,6 +71,30 @@ TEST(string_list, nextof) {
     CHECK(str == NULL);
 }
 
+TEST(string_list, prevof) {
+    StringList sl(arena);
+
+    CHECK(sl.push_back("foo"));
+    CHECK(sl.push_back("bar"));
+    CHECK(sl.push_back("baz"));
+
+    LONGS_EQUAL(3, sl.size());
+
+    const char* str = NULL;
+
+    str = sl.back();
+    STRCMP_EQUAL("baz", str);
+
+    str = sl.prevof(str);
+    STRCMP_EQUAL("bar", str);
+
+    str = sl.prevof(str);
+    STRCMP_EQUAL("foo", str);
+
+    str = sl.prevof(str);
+    CHECK(str == NULL);
+}
+
 TEST(string_list, copy) {
     StringList sl(arena);
 
@@ -116,7 +140,7 @@ TEST(string_list, empty_strings) {
     CHECK(str == NULL);
 }
 
-TEST(string_list, uniq) {
+TEST(string_list, find) {
     StringList sl(arena);
 
     CHECK(sl.push_back("foo"));
@@ -125,10 +149,10 @@ TEST(string_list, uniq) {
 
     LONGS_EQUAL(3, sl.size());
 
-    CHECK(sl.push_unique("bar"));
-    CHECK(sl.push_unique("qux"));
+    CHECK(sl.find("bar"));
+    CHECK(!sl.find("qux"));
 
-    LONGS_EQUAL(4, sl.size());
+    LONGS_EQUAL(3, sl.size());
 
     const char* str = NULL;
 
@@ -140,9 +164,6 @@ TEST(string_list, uniq) {
 
     str = sl.nextof(str);
     STRCMP_EQUAL("baz", str);
-
-    str = sl.nextof(str);
-    STRCMP_EQUAL("qux", str);
 
     str = sl.nextof(str);
     CHECK(str == NULL);
@@ -195,10 +216,11 @@ TEST(string_list, exponential_growth) {
     int num_reallocs = 0;
 
     int expected_reallocs[] = {
-        1, 1, 1, 1,                                    //
-        2, 2, 2, 2,                                    //
-        3, 3, 3, 3, 3, 3, 3, 3,                        //
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 //
+        1, 1, 1,                               //
+        2, 2, 2,                               //
+        3, 3, 3, 3, 3, 3,                      //
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, //
+        5, 5, 5, 5, 5, 5, 5                    //
     };
 
     for (size_t n = 0; n < ROC_ARRAY_SIZE(expected_reallocs); n++) {


### PR DESCRIPTION
pull request for #617 

string lengths are stored as size_t and written to the buffer just before the string.

changed tests to create new expected allocation counts to account for different size_t sizes.

any suggested changes are welcome and appreciated