### PR TITLE
print_supported implemented for recv and send tools.

### DIFF
--- a/src/internal_modules/roc_address/print_supported.cpp
+++ b/src/internal_modules/roc_address/print_supported.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_address/print_supported.h"
+#include "roc_address/protocol_map.h"
+#include "roc_core/log.h"
+#include "roc_core/printer.h"
+
+namespace roc {
+namespace address {
+
+namespace {
+
+enum { LineSize = 70 };
+
+void print_interface_protos(core::Printer& prn,
+                            Interface interface,
+                            const core::StringList& list) {
+    const char* str = list.front();
+
+    while (str != NULL) {
+        prn.writef(" ");
+
+        size_t size = 0;
+
+        prn.writef(" %s:", interface_to_str(interface));
+
+        while (size < LineSize) {
+            size += prn.writef(" %s%s%s", "", str, "://");
+
+            str = list.nextof(str);
+            if (!str) {
+                break;
+            }
+        }
+
+        prn.writef("\n");
+    }
+}
+
+} // namespace
+
+bool print_supported(ProtocolMap& protocol_map, core::IArena& arena) {
+    core::Printer prn;
+    core::Array<Interface> interface_array(arena);
+    core::StringList list(arena);
+
+    if (!protocol_map.get_supported_interfaces(interface_array)) {
+        roc_log(LogError, "can't retrieve interface array");
+        return false;
+    }
+
+    for (size_t n_interface = 0; n_interface < interface_array.size(); n_interface++) {
+        if (!protocol_map.get_supported_protocols(interface_array[n_interface], list)) {
+            roc_log(LogError, "can't retrieve protocols list");
+            return false;
+        }
+
+        if (n_interface == 0) {
+            prn.writef("\nsupported network protocols:\n");
+        }
+
+        print_interface_protos(prn, interface_array[n_interface], list);
+    }
+    return true;
+}
+
+} // namespace address
+} // namespace roc

--- a/src/internal_modules/roc_address/print_supported.h
+++ b/src/internal_modules/roc_address/print_supported.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_address/print_supported.h
+//! @brief Print supported interfaces and protocols.
+
+#ifndef ROC_ADDRESS_PRINT_SUPPORTED_H_
+#define ROC_ADDRESS_PRINT_SUPPORTED_H_
+
+#include "roc_address/protocol_map.h"
+#include "roc_core/attributes.h"
+#include "roc_core/iarena.h"
+
+namespace roc {
+namespace address {
+
+//! Print supported interfaces and protocols.
+ROC_ATTR_NODISCARD bool print_supported(ProtocolMap&, core::IArena&);
+
+} // namespace address
+} // namespace roc
+
+#endif // ROC_ADDRESS_PRINT_SUPPORTED_H_

--- a/src/internal_modules/roc_address/protocol_map.cpp
+++ b/src/internal_modules/roc_address/protocol_map.cpp
@@ -121,6 +121,56 @@ const ProtocolAttrs* ProtocolMap::find_by_scheme(const char* scheme) const {
     return NULL;
 }
 
+bool ProtocolMap::get_supported_interfaces(core::Array<Interface>& interface_array) {
+    interface_array.clear();
+    bool interfaces_exist = false;
+
+    for (unsigned n_iface = (unsigned)Iface_Consolidated; n_iface != (unsigned)Iface_Max;
+         n_iface++) {
+        for (size_t n_proto = 0; n_proto < MaxProtos; n_proto++) {
+            if (protos_[n_proto].protocol == Proto_None) {
+                continue;
+            }
+
+            if (n_iface == (unsigned)protos_[n_proto].iface) {
+                if (!interface_array.grow(interface_array.size() + 1)) {
+                    return false;
+                }
+                interface_array.push_back(protos_[n_proto].iface);
+                interfaces_exist = true;
+                break;
+            }
+        }
+    }
+
+    return interfaces_exist;
+}
+
+bool ProtocolMap::get_supported_protocols(Interface interface, core::StringList& list) {
+    list.clear();
+
+    bool protocols_exist = false;
+
+    for (size_t n_proto = 0; n_proto < MaxProtos; n_proto++) {
+        if (protos_[n_proto].protocol == Proto_None) {
+            continue;
+        }
+
+        if (interface == ProtocolMap::instance().protos_[n_proto].iface) {
+            const char* proto_name = protos_[n_proto].scheme_name;
+
+            if (!list.find(proto_name)) {
+                if (!list.push_back(proto_name)) {
+                    return false;
+                }
+            }
+            protocols_exist = true;
+        }
+    }
+
+    return protocols_exist;
+}
+
 void ProtocolMap::add_proto_(const ProtocolAttrs& proto) {
     roc_panic_if((int)proto.protocol < 0);
     roc_panic_if((int)proto.protocol >= MaxProtos);

--- a/src/internal_modules/roc_address/protocol_map.h
+++ b/src/internal_modules/roc_address/protocol_map.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Roc Streaming authors
+ * Copyright (c) 2023 Roc Streaming authors
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,9 +14,11 @@
 
 #include "roc_address/interface.h"
 #include "roc_address/protocol.h"
+#include "roc_core/array.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/singleton.h"
 #include "roc_core/stddefs.h"
+#include "roc_core/string_list.h"
 #include "roc_packet/fec.h"
 
 namespace roc {
@@ -65,6 +67,12 @@ public:
 
     //! Get protocol attributes by scheme name.
     const ProtocolAttrs* find_by_scheme(const char* scheme) const;
+
+    //! Get list of interfaces with at least one protocol.
+    ROC_ATTR_NODISCARD bool get_supported_interfaces(core::Array<Interface>&);
+
+    //! Get all supported protocols.
+    ROC_ATTR_NODISCARD bool get_supported_protocols(Interface, core::StringList&);
 
 private:
     friend class core::Singleton<ProtocolMap>;

--- a/src/internal_modules/roc_sndio/print_supported.cpp
+++ b/src/internal_modules/roc_sndio/print_supported.cpp
@@ -16,7 +16,7 @@ namespace sndio {
 
 namespace {
 
-enum { ArraySize = 100, LineSize = 70 };
+enum { LineSize = 70 };
 
 void print_string_list(core::Printer& prn,
                        const core::StringList& list,

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -8,6 +8,8 @@
 
 #include "roc_address/endpoint_uri.h"
 #include "roc_address/io_uri.h"
+#include "roc_address/print_supported.h"
+#include "roc_address/protocol_map.h"
 #include "roc_audio/freq_estimator.h"
 #include "roc_audio/resampler_profile.h"
 #include "roc_core/array.h"
@@ -94,6 +96,12 @@ int main(int argc, char** argv) {
         if (!sndio::print_supported(backend_dispatcher, context.arena())) {
             return 1;
         }
+
+        if (!address::print_supported(address::ProtocolMap::instance(),
+                                      context.arena())) {
+            return 1;
+        }
+
         return 0;
     }
 

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -8,6 +8,7 @@
 
 #include "roc_address/endpoint_uri.h"
 #include "roc_address/io_uri.h"
+#include "roc_address/print_supported.h"
 #include "roc_address/protocol_map.h"
 #include "roc_audio/resampler_profile.h"
 #include "roc_core/array.h"
@@ -93,6 +94,12 @@ int main(int argc, char** argv) {
         if (!sndio::print_supported(backend_dispatcher, context.arena())) {
             return 1;
         }
+
+        if (!address::print_supported(address::ProtocolMap::instance(),
+                                      context.arena())) {
+            return 1;
+        }
+
         return 0;
     }
 


### PR DESCRIPTION
Issue #578 

I am uncertain if the consolidated interface enumeration and its corresponding protocol should be a part of the printed list, but otherwise I believe I've done this all correctly.