### PR TITLE
Parsing float for duration and size

### DIFF
--- a/docs/sphinx/manuals/roc_copy.rst
+++ b/docs/sphinx/manuals/roc_copy.rst
@@ -59,6 +59,12 @@ The path component of the provided URI is `percent-decoded <https://en.wikipedia
 
 For example, the file named ``/foo/bar%/[baz]`` may be specified using either of the following URIs: ``file:///foo%2Fbar%25%2F%5Bbaz%5D`` and ``file:///foo/bar%25/[baz]``.
 
+Time units
+----------
+
+*TIME* should have one of the following forms:
+  123ns; 1.23us; 1.23ms; 1.23s; 1.23m; 1.23h;
+
 EXAMPLES
 ========
 

--- a/docs/sphinx/manuals/roc_recv.rst
+++ b/docs/sphinx/manuals/roc_recv.rst
@@ -158,13 +158,13 @@ Time units
 ----------
 
 *TIME* should have one of the following forms:
-  123ns, 123us, 123ms, 123s, 123m, 123h
+  123ns; 1.23us; 1.23ms; 1.23s; 1.23m; 1.23h;
 
 Size units
 ----------
 
 *SIZE* should have one of the following forms:
-  123; 123K; 123M; 123G;
+  123; 1.23K; 1.23M; 1.23G;
 
 EXAMPLES
 ========

--- a/docs/sphinx/manuals/roc_send.rst
+++ b/docs/sphinx/manuals/roc_send.rst
@@ -134,13 +134,13 @@ Time units
 ----------
 
 *TIME* should have one of the following forms:
-  123ns, 123us, 123ms, 123s, 123m, 123h
+  123ns; 1.23us; 1.23ms; 1.23s; 1.23m; 1.23h;
 
 Size units
 ----------
 
 *SIZE* should have one of the following forms:
-  123; 123K; 123M; 123G;
+  123; 1.23K; 1.23M; 1.23G;
 
 EXAMPLES
 ========

--- a/src/tools/roc_copy/cmdline.ggo
+++ b/src/tools/roc_copy/cmdline.ggo
@@ -38,8 +38,8 @@ FILE_URI defines an absolute or relative file path, e.g.:
 FILE_FORMAT is the output file format name, e.g.:
   wav; ogg; mp3
 
-TIME is an integer number with a suffix, e.g.:
-  123ns; 123us; 123ms; 123s; 123m; 123h;
+TIME is an integer or floating-point number with a suffix, e.g.:
+  123ns; 1.23us; 1.23ms; 1.23s; 1.23m; 1.23h;
 
 Use --list-supported option to print the list of the supported
 URI schemes and file formats.

--- a/src/tools/roc_recv/cmdline.ggo
+++ b/src/tools/roc_recv/cmdline.ggo
@@ -89,11 +89,11 @@ IO_URI is a device or file URI, e.g.:
 FILE_FORMAT is the output file format name, e.g.:
   wav; ogg; mp3
 
-TIME is an integer number with a suffix, e.g.:
-  123ns; 123us; 123ms; 123s; 123m; 123h;
+TIME is an integer or floating-point number with a suffix, e.g.:
+  123ns; 1.23us; 1.23ms; 1.23s; 1.23m; 1.23h;
 
-SIZE is an integer number with an optional suffix, e.g.:
-  123; 123K; 123M; 123G;
+SIZE is an integer or floating-point number with an optional suffix, e.g.:
+  123; 1.23K; 1.23M; 1.23G;
 
 Use --list-supported option to print the list of the supported
 URI schemes and file formats.

--- a/src/tools/roc_send/cmdline.ggo
+++ b/src/tools/roc_send/cmdline.ggo
@@ -68,11 +68,11 @@ IO_URI is a device or file URI, e.g.:
 FILE_FORMAT is the output file format name, e.g.:
   wav; ogg; mp3
 
-TIME is an integer number with a suffix, e.g.:
-  123ns; 123us; 123ms; 123s; 123m; 123h;
+TIME is an integer or floating-point number with a suffix, e.g.:
+  123ns; 1.23us; 1.23ms; 1.23s; 1.23m; 1.23h;
 
-SIZE is an integer number with an optional suffix, e.g.:
-  123; 123K; 123M; 123G;
+SIZE is an integer or floating-point number with an optional suffix, e.g.:
+  123; 1.23K; 1.23M; 1.23G;
 
 Use --list-supported option to print the list of the supported
 URI schemes and file formats.


### PR DESCRIPTION
# Why

For https://github.com/roc-streaming/roc-toolkit/issues/654

# What

* Updated the functions to use strod which parses a double.
  * After multiplying with multiplier, used round() function. 
  * Ensured that the nanoseconds_t and size_t are not overflowed, by checking difference.
* Updated tests

# Testing

There are tests.