### PR TITLE
Ubuntu 24.04 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - script: linux-x86_64/ubuntu-24.04
+            image: rocstreaming/env-ubuntu:24.04
+
           - script: linux-x86_64/ubuntu-22.04
             image: rocstreaming/env-ubuntu:22.04
 

--- a/docs/sphinx/development/continuous_integration.rst
+++ b/docs/sphinx/development/continuous_integration.rst
@@ -31,6 +31,7 @@ Linux native
 =================================== ===================== ============= ==================================
 Image                               Base image            Architecture  Compilers
 =================================== ===================== ============= ==================================
+rocstreaming/env-ubuntu:24.04       ubuntu:24.04          x86_64        gcc-13, clang-15, clang-17
 rocstreaming/env-ubuntu:22.04       ubuntu:22.04          x86_64        gcc-11, gcc-12, clang-11, clang-14
 rocstreaming/env-ubuntu:20.04       ubuntu:20.04          x86_64        gcc-8, gcc-10, clang-8, clang-10
 rocstreaming/env-ubuntu:18.04       ubuntu:18.04          x86_64        gcc-6, clang-6

--- a/scripts/ci_checks/linux-x86_64/ubuntu-24.04.sh
+++ b/scripts/ci_checks/linux-x86_64/ubuntu-24.04.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+for comp in gcc-13 clang-15 clang-17
+do
+    scons -Q \
+          --enable-werror \
+          --enable-tests \
+          --enable-benchmarks \
+          --enable-examples \
+          --build-3rdparty=openfec \
+          --compiler=${comp} \
+          test
+done


### PR DESCRIPTION
# Why

For https://github.com/roc-streaming/roc-toolkit/issues/634

This adds the ci builds.

# What

* Wrote script for Ubuntu 24.04.
  * Supported the 2 latest g++ and clang versions for building.
* Updated build.yml.

# Testing

Should run on CI.