### PR TITLE
NO_COLOR and FORCE_COLOR env vars support

### DIFF
--- a/docs/man/roc-copy.1
+++ b/docs/man/roc-copy.1
@@ -70,16 +70,16 @@ Duration of the internal frames, TIME units
 Output sample rate, Hz
 .TP
 .BI \-\-resampler\-backend\fB= ENUM
-Resampler backend  (possible values=\(dqdefault\(dq, \(dqbuiltin\(dq, \(dqspeex\(dq, \(dqspeexdec\(dq default=\(gadefault\(aq)
+Resampler backend  (possible values="default", "builtin", "speex", "speexdec" default=\(gadefault\(aq)
 .TP
 .BI \-\-resampler\-profile\fB= ENUM
-Resampler profile  (possible values=\(dqlow\(dq, \(dqmedium\(dq, \(dqhigh\(dq default=\(gamedium\(aq)
+Resampler profile  (possible values="low", "medium", "high" default=\(gamedium\(aq)
 .TP
 .B  \-\-profiling
 Enable self profiling  (default=off)
 .TP
 .BI \-\-color\fB= ENUM
-Set colored logging mode for stderr output (possible values=\(dqauto\(dq, \(dqalways\(dq, \(dqnever\(dq default=\(gaauto\(aq)
+Set colored logging mode for stderr output (possible values="auto", "always", "never" default=\(gaauto\(aq)
 .UNINDENT
 .SS File URI
 .sp
@@ -88,7 +88,7 @@ Set colored logging mode for stderr output (possible values=\(dqauto\(dq, \(dqal
 .IP \(bu 2
 \fBfile:///ABS/PATH\fP \-\- absolute file path
 .IP \(bu 2
-\fBfile://localhost/ABS/PATH\fP \-\- absolute file path (alternative form; only \(dqlocalhost\(dq host is supported)
+\fBfile://localhost/ABS/PATH\fP \-\- absolute file path (alternative form; only "localhost" host is supported)
 .IP \(bu 2
 \fBfile:/ABS/PATH\fP \-\- absolute file path (alternative form)
 .IP \(bu 2
@@ -159,6 +159,17 @@ $ roc\-copy \-vv \-\-input\-format=wav \-i file:\- \e
 .ft P
 .fi
 .UNINDENT
+.UNINDENT
+.SH ENVIRONMENT VARIABLES
+.sp
+The following environment variables are supported:
+.INDENT 0.0
+.TP
+.B NO_COLOR
+Terminal coloring is automatically detected. This environment variable can be set to non\-empty string to disable terminal coloring.
+.TP
+.B FORCE_COLOR
+Terminal coloring is automatically detected. This environment variable can be set to a positive integer to enable/force terminal coloring.
 .UNINDENT
 .SH SEE ALSO
 .sp

--- a/docs/man/roc-recv.1
+++ b/docs/man/roc-recv.1
@@ -106,16 +106,16 @@ Maximum internal frame size, in SIZE units
 Override output sample rate, Hz
 .TP
 .BI \-\-clock\-backend\fB= ENUM
-Clock synchronization backend  (possible values=\(dqdisable\(dq, \(dqniq\(dq default=\(ganiq\(aq)
+Clock synchronization backend  (possible values="disable", "niq" default=\(ganiq\(aq)
 .TP
 .BI \-\-clock\-profile\fB= ENUM
-Clock synchronization profile  (possible values=\(dqdefault\(dq, \(dqresponsive\(dq, \(dqgradual\(dq default=\(gadefault\(aq)
+Clock synchronization profile  (possible values="default", "responsive", "gradual" default=\(gadefault\(aq)
 .TP
 .BI \-\-resampler\-backend\fB= ENUM
-Resampler backend  (possible values=\(dqdefault\(dq, \(dqbuiltin\(dq, \(dqspeex\(dq, \(dqspeexdec\(dq default=\(gadefault\(aq)
+Resampler backend  (possible values="default", "builtin", "speex", "speexdec" default=\(gadefault\(aq)
 .TP
 .BI \-\-resampler\-profile\fB= ENUM
-Resampler profile  (possible values=\(dqlow\(dq, \(dqmedium\(dq, \(dqhigh\(dq default=\(gamedium\(aq)
+Resampler profile  (possible values="low", "medium", "high" default=\(gamedium\(aq)
 .TP
 .B  \-1\fP,\fB  \-\-oneshot
 Exit when last connected client disconnects (default=off)
@@ -127,7 +127,7 @@ Enable self\-profiling  (default=off)
 Enable beeping on packet loss  (default=off)
 .TP
 .BI \-\-color\fB= ENUM
-Set colored logging mode for stderr output (possible values=\(dqauto\(dq, \(dqalways\(dq, \(dqnever\(dq default=\(gaauto\(aq)
+Set colored logging mode for stderr output (possible values="auto", "always", "never" default=\(gaauto\(aq)
 .UNINDENT
 .SS Endpoint URI
 .sp
@@ -189,7 +189,7 @@ Supported control protocols:
 .IP \(bu 2
 \fBfile:///ABS/PATH\fP \-\- absolute file path
 .IP \(bu 2
-\fBfile://localhost/ABS/PATH\fP \-\- absolute file path (alternative form; only \(dqlocalhost\(dq host is supported)
+\fBfile://localhost/ABS/PATH\fP \-\- absolute file path (alternative form; only "localhost" host is supported)
 .IP \(bu 2
 \fBfile:/ABS/PATH\fP \-\- absolute file path (alternative form)
 .IP \(bu 2
@@ -537,6 +537,17 @@ $ roc\-recv \-vv \-s rtp://0.0.0.0:10001 \e
 .ft P
 .fi
 .UNINDENT
+.UNINDENT
+.SH ENVIRONMENT VARIABLES
+.sp
+The following environment variables are supported:
+.INDENT 0.0
+.TP
+.B NO_COLOR
+Terminal coloring is automatically detected. This environment variable can be set to non\-empty string to disable terminal coloring.
+.TP
+.B FORCE_COLOR
+Terminal coloring is automatically detected. This environment variable can be set to a positive integer to enable/force terminal coloring.
 .UNINDENT
 .SH SEE ALSO
 .sp

--- a/docs/man/roc-send.1
+++ b/docs/man/roc-send.1
@@ -94,10 +94,10 @@ Maximum internal frame size, in SIZE units
 Override input sample rate, Hz
 .TP
 .BI \-\-resampler\-backend\fB= ENUM
-Resampler backend  (possible values=\(dqdefault\(dq, \(dqbuiltin\(dq, \(dqspeex\(dq, \(dqspeexdec\(dq default=\(gadefault\(aq)
+Resampler backend  (possible values="default", "builtin", "speex", "speexdec" default=\(gadefault\(aq)
 .TP
 .BI \-\-resampler\-profile\fB= ENUM
-Resampler profile  (possible values=\(dqlow\(dq, \(dqmedium\(dq, \(dqhigh\(dq default=\(gamedium\(aq)
+Resampler profile  (possible values="low", "medium", "high" default=\(gamedium\(aq)
 .TP
 .B  \-\-interleaving
 Enable packet interleaving  (default=off)
@@ -106,7 +106,7 @@ Enable packet interleaving  (default=off)
 Enable self profiling  (default=off)
 .TP
 .BI \-\-color\fB= ENUM
-Set colored logging mode for stderr output (possible values=\(dqauto\(dq, \(dqalways\(dq, \(dqnever\(dq default=\(gaauto\(aq)
+Set colored logging mode for stderr output (possible values="auto", "always", "never" default=\(gaauto\(aq)
 .UNINDENT
 .SS Endpoint URI
 .sp
@@ -168,7 +168,7 @@ Supported control protocols:
 .IP \(bu 2
 \fBfile:///ABS/PATH\fP \-\- absolute file path
 .IP \(bu 2
-\fBfile://localhost/ABS/PATH\fP \-\- absolute file path (alternative form; only \(dqlocalhost\(dq host is supported)
+\fBfile://localhost/ABS/PATH\fP \-\- absolute file path (alternative form; only "localhost" host is supported)
 .IP \(bu 2
 \fBfile:/ABS/PATH\fP \-\- absolute file path (alternative form)
 .IP \(bu 2
@@ -441,6 +441,17 @@ $ roc\-send \-vv \-s rtp://192.168.0.3:10001 \e
 .ft P
 .fi
 .UNINDENT
+.UNINDENT
+.SH ENVIRONMENT VARIABLES
+.sp
+The following environment variables are supported:
+.INDENT 0.0
+.TP
+.B NO_COLOR
+Terminal coloring is automatically detected. This environment variable can be set to non\-empty string to disable terminal coloring.
+.TP
+.B FORCE_COLOR
+Terminal coloring is automatically detected. This environment variable can be set to a positive integer to enable/force terminal coloring.
 .UNINDENT
 .SH SEE ALSO
 .sp

--- a/docs/sphinx/manuals/roc_copy.rst
+++ b/docs/sphinx/manuals/roc_copy.rst
@@ -87,6 +87,17 @@ Input from stdin, output to stdout:
     $ roc-copy -vv --input-format=wav -i file:- \
         --output-format=wav -o file:- >./output.wav <./input.wav
 
+ENVIRONMENT VARIABLES
+=====================
+
+The following environment variables are supported:
+
+NO_COLOR
+    Terminal coloring is automatically detected. This environment variable can be set to non-empty string to disable terminal coloring.
+
+FORCE_COLOR
+    Terminal coloring is automatically detected. This environment variable can be set to a positive integer to enable/force terminal coloring.
+
 SEE ALSO
 ========
 

--- a/docs/sphinx/manuals/roc_recv.rst
+++ b/docs/sphinx/manuals/roc_recv.rst
@@ -318,6 +318,17 @@ Manually specify clock synchronization parameters:
     $ roc-recv -vv -s rtp://0.0.0.0:10001 \
         --clock-backend=niq --clock-profile=gradual
 
+ENVIRONMENT VARIABLES
+=====================
+
+The following environment variables are supported:
+
+NO_COLOR
+    Terminal coloring is automatically detected. This environment variable can be set to non-empty string to disable terminal coloring.
+
+FORCE_COLOR
+    Terminal coloring is automatically detected. This environment variable can be set to a positive integer to enable/force terminal coloring.
+
 SEE ALSO
 ========
 

--- a/docs/sphinx/manuals/roc_send.rst
+++ b/docs/sphinx/manuals/roc_send.rst
@@ -262,6 +262,17 @@ Manually specify resampling parameters:
     $ roc-send -vv -s rtp://192.168.0.3:10001 \
         --resampler-backend=speex --resampler-profile=high
 
+ENVIRONMENT VARIABLES
+=====================
+
+The following environment variables are supported:
+
+NO_COLOR
+    Terminal coloring is automatically detected. This environment variable can be set to non-empty string to disable terminal coloring.
+
+FORCE_COLOR
+    Terminal coloring is automatically detected. This environment variable can be set to a positive integer to enable/force terminal coloring.
+
 SEE ALSO
 ========
 


### PR DESCRIPTION
# Why

For https://github.com/roc-streaming/roc-toolkit/issues/564

# What

* Created functions to check for NO_COLOR and FORCE_COLOR.
* Created function to check if term supports color.
* Used those methods in detect_color_support()
  * Prefer NO_COLOR if both vars are available.
* Updated man sources.
* Generated man pages as well.

# Testing

* Tested NO_COLOR using ubuntu terminal.
![image](https://github.com/roc-streaming/roc-toolkit/assets/88709630/bd8ec74a-14d3-4b0d-ad34-de29a8382310)
* Tested FORCE_COLOR by using ssh to localhost.
![image](https://github.com/roc-streaming/roc-toolkit/assets/88709630/0f707da6-1ac3-437b-809b-1d80cdd203d7)
