### PR TITLE
Refactor arena & pool guards and logs

### DIFF
--- a/src/internal_modules/roc_core/ipool.h
+++ b/src/internal_modules/roc_core/ipool.h
@@ -25,6 +25,7 @@ public:
     virtual ~IPool();
 
     //! Get size of the allocation per object.
+    //! Covers all internal overhead, if any.
     virtual size_t allocation_size() const = 0;
 
     //! Reserve memory for given number of objects.

--- a/src/internal_modules/roc_core/slab_pool_impl.h
+++ b/src/internal_modules/roc_core/slab_pool_impl.h
@@ -64,7 +64,7 @@ public:
                  size_t max_alloc_bytes,
                  void* preallocated_data,
                  size_t preallocated_size,
-                 size_t flags);
+                 size_t guards);
 
     //! Deinitialize.
     ~SlabPoolImpl();
@@ -106,6 +106,8 @@ private:
     size_t slots_per_slab_(size_t slab_size, bool round_up) const;
     size_t slot_offset_(size_t slot_index) const;
 
+    bool report_guard_(size_t guard) const;
+
     Mutex mutex_;
 
     const char* name_;
@@ -128,8 +130,8 @@ private:
     const size_t object_size_;
     const size_t object_size_padding_;
 
-    const size_t flags_;
-    size_t num_guard_failures_;
+    const size_t guards_;
+    mutable size_t num_guard_failures_;
 };
 
 } // namespace core

--- a/src/tests/bench_main.cpp
+++ b/src/tests/bench_main.cpp
@@ -15,8 +15,8 @@
 using namespace roc;
 
 int main(int argc, char** argv) {
-    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                               | core::HeapArenaFlag_EnableLeakDetection);
+    core::HeapArena::set_guards(core::HeapArena_DefaultGuards
+                                | core::HeapArena_LeakGuard);
 
     core::CrashHandler crash_handler;
 

--- a/src/tests/roc_core/test_heap_arena.cpp
+++ b/src/tests/roc_core/test_heap_arena.cpp
@@ -17,11 +17,10 @@ namespace core {
 // clang-format off
 TEST_GROUP(heap_arena) {
     void setup() {
-        core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                                    & ~core::HeapArenaFlag_EnableGuards);
+        core::HeapArena::set_guards(0);
     }
     void teardown() {
-        core::HeapArena::set_flags(core::DefaultHeapArenaFlags);
+        core::HeapArena::set_guards(core::HeapArena_DefaultGuards);
     }
 };
 // clang-format on

--- a/src/tests/roc_core/test_limited_arena.cpp
+++ b/src/tests/roc_core/test_limited_arena.cpp
@@ -17,11 +17,10 @@ namespace core {
 // clang-format off
 TEST_GROUP(limited_arena) {
     void setup() {
-        core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                                    & ~core::HeapArenaFlag_EnableGuards);
+        core::HeapArena::set_guards(0);
     }
     void teardown() {
-        core::HeapArena::set_flags(core::DefaultHeapArenaFlags);
+        core::HeapArena::set_guards(core::HeapArena_DefaultGuards);
     }
 };
 // clang-format on

--- a/src/tests/roc_core/test_slab_pool.cpp
+++ b/src/tests/roc_core/test_slab_pool.cpp
@@ -500,7 +500,7 @@ TEST(slab_pool, guard_object) {
 TEST(slab_pool, guard_object_violations) {
     TestArena arena;
     SlabPool<TestObject, 1> pool("test", arena, sizeof(TestObject), 0, 0,
-                                 (DefaultSlabPoolFlags & ~SlabPoolFlag_EnableGuards));
+                                 (SlabPool_DefaultGuards & ~SlabPool_OverflowGuard));
     void* pointers[2] = {};
 
     pointers[0] = pool.allocate();
@@ -529,7 +529,7 @@ TEST(slab_pool, guard_object_violations) {
 TEST(slab_pool, object_ownership_guard) {
     TestArena arena;
     SlabPool<TestObject, 1> pool0("test", arena, sizeof(TestObject), 0, 0,
-                                  (DefaultSlabPoolFlags & ~SlabPoolFlag_EnableGuards));
+                                  (SlabPool_DefaultGuards & ~SlabPool_OwnershipGuard));
     SlabPool<TestObject, 1> pool1("test", arena);
 
     void* pointers[2] = {};

--- a/src/tests/test_main.cpp
+++ b/src/tests/test_main.cpp
@@ -18,8 +18,8 @@
 using namespace roc;
 
 int main(int argc, const char** argv) {
-    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                               | core::HeapArenaFlag_EnableLeakDetection);
+    core::HeapArena::set_guards(core::HeapArena_DefaultGuards
+                                | core::HeapArena_LeakGuard);
 
     core::CrashHandler crash_handler;
 

--- a/src/tools/roc_copy/main.cpp
+++ b/src/tools/roc_copy/main.cpp
@@ -24,8 +24,8 @@
 using namespace roc;
 
 int main(int argc, char** argv) {
-    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                               | core::HeapArenaFlag_EnableLeakDetection);
+    core::HeapArena::set_guards(core::HeapArena_DefaultGuards
+                                | core::HeapArena_LeakGuard);
 
     core::CrashHandler crash_handler;
 

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -31,8 +31,8 @@
 using namespace roc;
 
 int main(int argc, char** argv) {
-    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                               | core::HeapArenaFlag_EnableLeakDetection);
+    core::HeapArena::set_guards(core::HeapArena_DefaultGuards
+                                | core::HeapArena_LeakGuard);
 
     core::HeapArena heap_arena;
 

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -30,8 +30,8 @@
 using namespace roc;
 
 int main(int argc, char** argv) {
-    core::HeapArena::set_flags(core::DefaultHeapArenaFlags
-                               | core::HeapArenaFlag_EnableLeakDetection);
+    core::HeapArena::set_guards(core::HeapArena_DefaultGuards
+                                | core::HeapArena_LeakGuard);
 
     core::HeapArena heap_arena;
 


### PR DESCRIPTION
- Instead of more generic "flags" enum, use more specific "guards", so that it's easier to understand the purpose

- Use separate flag for each type of guard

- Extract method that increments failure counter and checks if panics are enabled for a guard

- Use same logging format as in MemoryLimiter