### PR TITLE
Issue 635: modified android-linux job matrix to check ndk21 and ndk26 for all ABIs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,17 +170,33 @@ jobs:
             toolchain: aarch64-linux-android29
             shortname: android29-aarch64
 
+          - image: rocstreaming/toolchain-linux-android:ndk26
+            toolchain: aarch64-linux-android29
+            shortname: android29-aarch64-ndk26
+
           - image: rocstreaming/toolchain-linux-android:ndk21
             toolchain: armv7a-linux-androideabi29
             shortname: android29-armv7a
+
+          - image: rocstreaming/toolchain-linux-android:ndk26
+            toolchain: armv7a-linux-androideabi29
+            shortname: android29-armv7a-ndk26
 
           - image: rocstreaming/toolchain-linux-android:ndk21
             toolchain: x86_64-linux-android29
             shortname: android29-x86_64
 
+          - image: rocstreaming/toolchain-linux-android:ndk26
+            toolchain: x86_64-linux-android29
+            shortname: android29-x86_64-ndk26
+
           - image: rocstreaming/toolchain-linux-android:ndk21
             toolchain: i686-linux-android29
             shortname: android29-i686
+
+          - image: rocstreaming/toolchain-linux-android:ndk26
+            toolchain: i686-linux-android29
+            shortname: android29-i686-ndk26
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
       - develop
-      - feature/*
-      - waspd/*
     tags:
       - v*
   pull_request:
@@ -27,9 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - script: linux-x86_64/ubuntu-24.04
-            image: rocstreaming/env-ubuntu:24.04
-
           - script: linux-x86_64/ubuntu-22.04
             image: rocstreaming/env-ubuntu:22.04
 
@@ -169,7 +164,7 @@ jobs:
           - image: rocstreaming/toolchain-linux-android:ndk21
             toolchain: aarch64-linux-android29
             shortname: android29-aarch64
-
+          
           - image: rocstreaming/toolchain-linux-android:ndk26
             toolchain: aarch64-linux-android29
             shortname: android29-aarch64-ndk26
@@ -227,7 +222,7 @@ jobs:
         include:
           - abi: x86_64
             api: 29
-            ndk: 25.2.9519653
+            ndk: 26.3.11579264
             build_tools: 28.0.3
             cmake: 3.10.2.4988404
             avd_abi: x86_64


### PR DESCRIPTION
Solves the second part of issue 635: https://github.com/roc-streaming/roc-toolkit/issues/635