### PR TITLE
Assign names to threads

### DIFF
--- a/src/internal_modules/roc_core/target_posix/roc_core/thread.h
+++ b/src/internal_modules/roc_core/target_posix/roc_core/thread.h
@@ -50,13 +50,24 @@ public:
     //!  Blocks until run() returns and thread terminates.
     void join();
 
+    //! Print thread name
+    //! @remarks
+    //! Prints thread name for ease of debugging.
+    void print_name();
+
 protected:
     virtual ~Thread();
 
-    Thread();
+    //! @remarks
+    //! Constructor now takes name argument
+    Thread(const char* name_);
 
     //! Method to be executed in thread.
     virtual void run() = 0;
+
+    //! @remarks
+    //! Method to assign name based on architecture.
+    bool assign_thread_name_();
 
 private:
     static void* thread_runner_(void* ptr);
@@ -65,7 +76,7 @@ private:
 
     int started_;
     Atomic<int> joinable_;
-
+    const char* name_;
     Mutex mutex_;
 };
 

--- a/src/internal_modules/roc_ctl/control_task_queue.cpp
+++ b/src/internal_modules/roc_ctl/control_task_queue.cpp
@@ -15,7 +15,8 @@ namespace roc {
 namespace ctl {
 
 ControlTaskQueue::ControlTaskQueue()
-    : started_(false)
+    : Thread("roc_ctrl_task_queue")
+    , started_(false)
     , stop_(false)
     , fetch_ready_(true)
     , ready_queue_size_(0) {

--- a/src/internal_modules/roc_netio/target_libuv/roc_netio/network_loop.cpp
+++ b/src/internal_modules/roc_netio/target_libuv/roc_netio/network_loop.cpp
@@ -105,7 +105,8 @@ NetworkLoop::Tasks::ResolveEndpointAddress::get_address() const {
 NetworkLoop::NetworkLoop(packet::PacketFactory& packet_factory,
                          core::BufferFactory<uint8_t>& buffer_factory,
                          core::IArena& arena)
-    : packet_factory_(packet_factory)
+    : Thread("roc_network_loop")
+    , packet_factory_(packet_factory)
     , buffer_factory_(buffer_factory)
     , arena_(arena)
     , started_(false)

--- a/src/tests/public_api/test_helpers/receiver.h
+++ b/src/tests/public_api/test_helpers/receiver.h
@@ -36,7 +36,8 @@ public:
              size_t num_chans,
              size_t frame_size,
              unsigned flags)
-        : recv_(NULL)
+        : Thread("roc_receiver")
+        , recv_(NULL)
         , sample_step_(sample_step)
         , num_chans_(num_chans)
         , frame_samples_(frame_size * num_chans)

--- a/src/tests/public_api/test_helpers/sender.h
+++ b/src/tests/public_api/test_helpers/sender.h
@@ -34,7 +34,8 @@ public:
            size_t num_chans,
            size_t frame_size,
            unsigned flags)
-        : sndr_(NULL)
+        : Thread("roc_sender")
+        , sndr_(NULL)
         , sample_step_(sample_step)
         , num_chans_(num_chans)
         , frame_samples_(frame_size * num_chans)

--- a/src/tests/roc_core/bench_mpsc_queue.cpp
+++ b/src/tests/roc_core/bench_mpsc_queue.cpp
@@ -84,7 +84,8 @@ private:
 class PushThread : public core::Thread {
 public:
     PushThread()
-        : bf_(NULL)
+        : Thread("roc_push_thread")
+        , bf_(NULL)
         , thread_index_(0) {
     }
 

--- a/src/tests/roc_core/test_timer.cpp
+++ b/src/tests/roc_core/test_timer.cpp
@@ -21,7 +21,8 @@ namespace {
 class TestThread : public Thread {
 public:
     TestThread(Timer& t)
-        : t_(t)
+        : Thread("roc_test_timer")
+        , t_(t)
         , r_(0) {
     }
 
@@ -87,6 +88,8 @@ TEST(timer, async) {
 
         TestThread thr(t);
         CHECK(thr.start());
+
+        thr.print_name();
 
         thr.wait_running();
         sleep_for(ClockMonotonic, Microsecond * 100);

--- a/src/tests/roc_netio/test_helpers/conn_reader.h
+++ b/src/tests/roc_netio/test_helpers/conn_reader.h
@@ -25,7 +25,8 @@ namespace test {
 class ConnReader : public core::Thread {
 public:
     ConnReader(MockConnHandler& handler, IConn& conn, size_t total_bytes)
-        : handler_(handler)
+        : Thread("roc_conn_reader")
+        , handler_(handler)
         , conn_(conn)
         , total_bytes_(total_bytes) {
     }

--- a/src/tests/roc_netio/test_helpers/conn_writer.h
+++ b/src/tests/roc_netio/test_helpers/conn_writer.h
@@ -26,7 +26,8 @@ namespace test {
 class ConnWriter : public core::Thread {
 public:
     ConnWriter(MockConnHandler& handler, IConn& conn, size_t total_bytes)
-        : handler_(handler)
+        : Thread("roc_conn_writer")
+        , handler_(handler)
         , conn_(conn)
         , total_bytes_(total_bytes) {
     }

--- a/src/tests/roc_packet/test_concurrent_queue.cpp
+++ b/src/tests/roc_packet/test_concurrent_queue.cpp
@@ -32,7 +32,8 @@ PacketPtr new_packet() {
 
 struct TestWriter : core::Thread {
     TestWriter(ConcurrentQueue& queue, PacketPtr packet)
-        : queue(queue)
+        : Thread("roc_test_writer")
+        , queue(queue)
         , packet(packet) {
     }
 

--- a/src/tests/roc_pipeline/bench_pipeline_loop_contention.cpp
+++ b/src/tests/roc_pipeline/bench_pipeline_loop_contention.cpp
@@ -49,10 +49,10 @@ public:
 
     NoopPipeline(const TaskConfig& config, ctl::ControlTaskQueue& control_queue)
         : PipelineLoop(
-            *this,
-            config,
-            audio::SampleSpec(
-                SampleRate, audio::ChanLayout_Surround, audio::ChanOrder_Smpte, Chans))
+              *this,
+              config,
+              audio::SampleSpec(
+                  SampleRate, audio::ChanLayout_Surround, audio::ChanOrder_Smpte, Chans))
         , control_queue_(control_queue)
         , control_task_(*this) {
     }

--- a/src/tests/roc_pipeline/bench_pipeline_loop_peak_load.cpp
+++ b/src/tests/roc_pipeline/bench_pipeline_loop_peak_load.cpp
@@ -271,10 +271,10 @@ public:
                  ctl::ControlTaskQueue& control_queue,
                  DelayStats& stats)
         : PipelineLoop(
-            *this,
-            config,
-            audio::SampleSpec(
-                SampleRate, audio::ChanLayout_Surround, audio::ChanOrder_Smpte, Chans))
+              *this,
+              config,
+              audio::SampleSpec(
+                  SampleRate, audio::ChanLayout_Surround, audio::ChanOrder_Smpte, Chans))
         , stats_(stats)
         , control_queue_(control_queue)
         , control_task_(*this) {
@@ -365,7 +365,8 @@ private:
 class TaskThread : public core::Thread, private IPipelineTaskCompleter {
 public:
     TaskThread(TestPipeline& pipeline)
-        : pipeline_(pipeline)
+        : Thread("roc_task_thread")
+        , pipeline_(pipeline)
         , stop_(false) {
     }
 

--- a/src/tests/roc_pipeline/test_pipeline_loop.cpp
+++ b/src/tests/roc_pipeline/test_pipeline_loop.cpp
@@ -367,7 +367,8 @@ public:
     AsyncTaskScheduler(TestPipeline& pipeline,
                        TestPipeline::Task& task,
                        TestCompleter* completer)
-        : pipeline_(pipeline)
+        : Thread("roc_async_task_scheduler")
+        , pipeline_(pipeline)
         , task_(task)
         , completer_(completer) {
     }
@@ -389,7 +390,8 @@ private:
 class AsyncTaskProcessor : public core::Thread {
 public:
     AsyncTaskProcessor(TestPipeline& pipeline)
-        : pipeline_(pipeline) {
+        : Thread("roc_async_task_processor")
+        , pipeline_(pipeline) {
     }
 
 private:
@@ -403,7 +405,8 @@ private:
 class AsyncFrameWriter : public core::Thread {
 public:
     AsyncFrameWriter(TestPipeline& pipeline, audio::Frame& frame)
-        : pipeline_(pipeline)
+        : Thread("roc_async_frame_writer")
+        , pipeline_(pipeline)
         , frame_(frame) {
     }
 


### PR DESCRIPTION
Added a thread name char * argument to Thread constructor and applied changes to inherited classes. Added assign_name_() method for different architectures. Also added print_name() method for debugging to keep name_ member private. 

Issue link: https://github.com/roc-streaming/roc-toolkit/issues/618