### PR TITLE
Fix unix-like platforms build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -772,7 +772,7 @@ else:
             'target_posix_pc',
         ])
 
-    if meta.platform in ['linux', 'android']:
+    if meta.platform in ['linux', 'android', 'unix']:
         env.Append(ROC_TARGETS=[
             'target_posix_ext',
         ])


### PR DESCRIPTION
semaphore.h is used in various places, and the implementation based on unix semaphores is largely supported by unix platforms.

Fixes:
src/internal_modules/roc_ctl/control_task.h:20:10: fatal error: roc_core/semaphore.h: No such file or directory
   20 | #include "roc_core/semaphore.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~