### PR TITLE
Fix debian rules for libdir installation

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,6 @@
 #!/usr/bin/make -f
 export DEB_HOST_GNU_TYPE ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)
+export DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 export DEB_BUILD_GNU_TYPE
 export DEB_BUILD_OPTIONS = nocheck
 export DEB_DH_SHLIBDEPS_ARGS_ALL = -- --ignore-missing-info -l/usr/lib/${DEB_BUILD_GNU_TYPE}/pulseaudio --warnings=5 -v
@@ -12,10 +13,12 @@ override_dh_auto_clean:
 
 override_dh_auto_build:
 	scons --prefix=/usr --host=${DEB_HOST_GNU_TYPE} \
+		--libdir=/usr/lib/${DEB_HOST_MULTIARCH} \
 		--build-3rdparty=libuv,libunwind,speexdsp,sox,openssl,openfec
 
 override_dh_auto_install:
 	scons --prefix=/usr --host=${DEB_HOST_GNU_TYPE} \
+		--libdir=/usr/lib/${DEB_HOST_MULTIARCH} \
 		--build-3rdparty=libuv,libunwind,speexdsp,sox,openssl,openfec \
 		install DESTDIR=debian/tmp
 


### PR DESCRIPTION
efbce5e94f99 ("Fix debian rules for host specification") fixed finding the proper toolchain, but roc-toolkit now installs libraries under the gnu type string, while Debian expects the multiarch path. So we need to explicitly set libdir to the multiarch path.