### PR TITLE
Implement StringList pop_back()

### DIFF
--- a/src/internal_modules/roc_core/string_list.cpp
+++ b/src/internal_modules/roc_core/string_list.cpp
@@ -130,6 +130,32 @@ bool StringList::push_back(const char* str_begin, const char* str_end) {
     return true;
 }
 
+bool StringList::pop_back() {
+    if (size_ == 0) {
+        roc_panic("stringlist: list is empty");
+    }
+
+    const size_t blk_sz = back_->len;
+    const Footer* prev_footer = NULL;
+    if (size_ > 1) {
+        prev_footer = (const Footer*)((const char*)back_ - sizeof(Footer));
+    }
+
+    if (!data_.resize(data_.size() - blk_sz)) {
+        return false;
+    }
+
+    size_--;
+    if (size_) {
+        back_ = (Header*)(data_.data() + data_.size() - prev_footer->len);
+    } else {
+        front_ = NULL;
+        back_ = NULL;
+    }
+
+    return true;
+}
+
 const char* StringList::find(const char* str) {
     if (str == NULL) {
         roc_panic("stringlist: string is null");

--- a/src/internal_modules/roc_core/string_list.h
+++ b/src/internal_modules/roc_core/string_list.h
@@ -87,6 +87,11 @@ public:
     //!  false if allocation failed.
     ROC_ATTR_NODISCARD bool push_back(const char* str_begin, const char* str_end);
 
+    //! Remove string from end of the list.
+    //! @returns
+    //!  false if deallocation failed.
+    ROC_ATTR_NODISCARD bool pop_back();
+
     //! Find string in the list.
     //! @returns
     //!  the string in the list or NULL if it is not found.

--- a/src/tests/roc_core/test_string_list.cpp
+++ b/src/tests/roc_core/test_string_list.cpp
@@ -47,6 +47,29 @@ TEST(string_list, push_back) {
     STRCMP_EQUAL("bar", sl.back());
 }
 
+TEST(string_list, pop_back) {
+    StringList sl(arena);
+
+    LONGS_EQUAL(0, sl.size());
+    CHECK(sl.push_back("foo"));
+    CHECK(sl.pop_back());
+    LONGS_EQUAL(0, sl.size());
+
+    CHECK(sl.push_back("foo"));
+    CHECK(sl.push_back("barbaz"));
+    CHECK(sl.pop_back());
+    LONGS_EQUAL(1, sl.size());
+    STRCMP_EQUAL("foo", sl.front());
+    STRCMP_EQUAL("foo", sl.back());
+
+    CHECK(sl.push_back("foobarbaz"));
+    CHECK(sl.push_back("baz"));
+    CHECK(sl.pop_back());
+    LONGS_EQUAL(2, sl.size());
+    STRCMP_EQUAL("foo", sl.front());
+    STRCMP_EQUAL("foobarbaz", sl.back());
+}
+
 TEST(string_list, push_back_range) {
     StringList sl(arena);
 


### PR DESCRIPTION
Fixes #669 

- Implemented a new "void pop_back()" method.
- Removes the last string from StringList.
- Returns false if deallocation fails
- Panics if StringList is empty.
- Clears when last string is poped.

Test cases covered:

- Size should be zero after removing last element from the list. 
- front_ and back_ have to point to same string when initial list with two strings is poped. 
- back_ should point to 'n-1' string after poping initial 'n' number of strings list.