### PR TITLE
Implemented explicit flushing of buffered samples from sink to file

### DIFF
--- a/src/internal_modules/roc_pipeline/sender_loop.cpp
+++ b/src/internal_modules/roc_pipeline/sender_loop.cpp
@@ -232,6 +232,12 @@ status::StatusCode SenderLoop::write(audio::Frame& frame) {
     return code;
 }
 
+status::StatusCode SenderLoop::flush() {
+    core::Mutex::Lock lock(sink_mutex_);
+
+    return sink_.flush();
+}
+
 core::nanoseconds_t SenderLoop::timestamp_imp() const {
     return core::timestamp(core::ClockMonotonic);
 }

--- a/src/internal_modules/roc_pipeline/sender_loop.h
+++ b/src/internal_modules/roc_pipeline/sender_loop.h
@@ -153,6 +153,7 @@ private:
     virtual bool has_clock() const;
     virtual status::StatusCode close();
     virtual status::StatusCode write(audio::Frame& frame);
+    virtual ROC_ATTR_NODISCARD status::StatusCode flush();
 
     // Methods of PipelineLoop
     virtual core::nanoseconds_t timestamp_imp() const;

--- a/src/internal_modules/roc_pipeline/sender_sink.cpp
+++ b/src/internal_modules/roc_pipeline/sender_sink.cpp
@@ -260,5 +260,9 @@ status::StatusCode SenderSink::write(audio::Frame& frame) {
     return code;
 }
 
+status::StatusCode SenderSink::flush() {
+    return status::StatusOK;
+}
+
 } // namespace pipeline
 } // namespace roc

--- a/src/internal_modules/roc_pipeline/sender_sink.h
+++ b/src/internal_modules/roc_pipeline/sender_sink.h
@@ -115,6 +115,9 @@ public:
     //! Write frame.
     virtual ROC_ATTR_NODISCARD status::StatusCode write(audio::Frame& frame);
 
+    //! Flush buffered data, if any.
+    virtual ROC_ATTR_NODISCARD status::StatusCode flush();
+
 private:
     SenderSinkConfig sink_config_;
 

--- a/src/internal_modules/roc_pipeline/transcoder_sink.cpp
+++ b/src/internal_modules/roc_pipeline/transcoder_sink.cpp
@@ -136,5 +136,9 @@ status::StatusCode TranscoderSink::write(audio::Frame& frame) {
     return frame_writer_->write(frame);
 }
 
+status::StatusCode TranscoderSink::flush() {
+    return status::StatusOK;
+}
+
 } // namespace pipeline
 } // namespace roc

--- a/src/internal_modules/roc_pipeline/transcoder_sink.h
+++ b/src/internal_modules/roc_pipeline/transcoder_sink.h
@@ -72,6 +72,9 @@ public:
     //! Write frame.
     virtual ROC_ATTR_NODISCARD status::StatusCode write(audio::Frame& frame);
 
+    //! Flush buffered data, if any.
+    virtual ROC_ATTR_NODISCARD status::StatusCode flush();
+
 private:
     audio::FrameFactory frame_factory_;
 

--- a/src/internal_modules/roc_sndio/isink.h
+++ b/src/internal_modules/roc_sndio/isink.h
@@ -14,6 +14,7 @@
 
 #include "roc_audio/iframe_writer.h"
 #include "roc_sndio/idevice.h"
+#include "roc_status/status_code.h"
 
 namespace roc {
 namespace sndio {
@@ -22,6 +23,9 @@ namespace sndio {
 class ISink : virtual public IDevice, public audio::IFrameWriter {
 public:
     virtual ~ISink();
+
+    //! Flush buffered data, if any.
+    virtual ROC_ATTR_NODISCARD status::StatusCode flush() = 0;
 };
 
 } // namespace sndio

--- a/src/internal_modules/roc_sndio/pump.cpp
+++ b/src/internal_modules/roc_sndio/pump.cpp
@@ -71,6 +71,13 @@ status::StatusCode Pump::run() {
     if (code == status::StatusFinish) {
         code = status::StatusOK; // EOF is fine
     }
+    if (code == status::StatusOK) {
+        code = sink_.flush();
+        if (code != status::StatusOK) {
+            roc_log(LogError, "pump: got error when flushing sink: status=%s",
+                    status::code_to_str(code));
+        }
+    }
 
     status::StatusCode close_code = close_all_devices_();
 

--- a/src/internal_modules/roc_sndio/target_pulseaudio/roc_sndio/pulseaudio_device.cpp
+++ b/src/internal_modules/roc_sndio/target_pulseaudio/roc_sndio/pulseaudio_device.cpp
@@ -334,6 +334,10 @@ status::StatusCode PulseaudioDevice::write(audio::Frame& frame) {
     return handle_request_(frame.bytes(), frame.num_bytes());
 }
 
+status::StatusCode PulseaudioDevice::flush() {
+    return status::StatusOK;
+}
+
 status::StatusCode PulseaudioDevice::read(audio::Frame& frame,
                                           packet::stream_timestamp_t duration,
                                           audio::FrameReadMode mode) {

--- a/src/internal_modules/roc_sndio/target_pulseaudio/roc_sndio/pulseaudio_device.h
+++ b/src/internal_modules/roc_sndio/target_pulseaudio/roc_sndio/pulseaudio_device.h
@@ -101,6 +101,9 @@ public:
          packet::stream_timestamp_t duration,
          audio::FrameReadMode mode);
 
+    //! Flush buffered data, if any.
+    virtual ROC_ATTR_NODISCARD status::StatusCode flush();
+
 private:
     static void context_state_cb_(pa_context* context, void* userdata);
 

--- a/src/internal_modules/roc_sndio/target_sndfile/roc_sndio/sndfile_sink.cpp
+++ b/src/internal_modules/roc_sndio/target_sndfile/roc_sndio/sndfile_sink.cpp
@@ -250,6 +250,10 @@ status::StatusCode SndfileSink::write(audio::Frame& frame) {
     return status::StatusOK;
 }
 
+status::StatusCode SndfileSink::flush() {
+    return status::StatusOK;
+}
+
 status::StatusCode SndfileSink::open_(const char* driver, const char* path) {
     if (!map_to_sndfile(&driver, path, file_info_)) {
         roc_log(LogDebug,

--- a/src/internal_modules/roc_sndio/target_sndfile/roc_sndio/sndfile_sink.h
+++ b/src/internal_modules/roc_sndio/target_sndfile/roc_sndio/sndfile_sink.h
@@ -69,6 +69,9 @@ public:
     //! Write frame.
     virtual ROC_ATTR_NODISCARD status::StatusCode write(audio::Frame& frame);
 
+    //! Flush buffered data, if any.
+    virtual ROC_ATTR_NODISCARD status::StatusCode flush();
+
 private:
     status::StatusCode open_(const char* driver, const char* path);
     status::StatusCode close_();

--- a/src/internal_modules/roc_sndio/target_sox/roc_sndio/sox_sink.cpp
+++ b/src/internal_modules/roc_sndio/target_sox/roc_sndio/sox_sink.cpp
@@ -219,9 +219,21 @@ status::StatusCode SoxSink::write(audio::Frame& frame) {
         }
     }
 
-    const status::StatusCode code = write_(buffer_data, buffer_pos);
-    if (code != status::StatusOK) {
-        return code;
+    if (buffer_pos > 0) {
+        const status::StatusCode code = write_(buffer_data, buffer_pos);
+        if (code != status::StatusOK) {
+            return code;
+        }
+    }
+
+    return status::StatusOK;
+}
+
+status::StatusCode SoxSink::flush() {
+    if (output_ != NULL && driver_type_ == DriverType_File && output_->fp != NULL) {
+        if (fflush((FILE*)output_->fp) != 0) {
+            return status::StatusErrFile;
+        }
     }
 
     return status::StatusOK;

--- a/src/internal_modules/roc_sndio/target_sox/roc_sndio/sox_sink.h
+++ b/src/internal_modules/roc_sndio/target_sox/roc_sndio/sox_sink.h
@@ -81,6 +81,9 @@ public:
     //! Write frame.
     virtual ROC_ATTR_NODISCARD status::StatusCode write(audio::Frame& frame);
 
+    //! Flush buffered data, if any.
+    virtual ROC_ATTR_NODISCARD status::StatusCode flush();
+
 private:
     status::StatusCode init_names_(const char* driver, const char* path);
     status::StatusCode init_buffer_();

--- a/src/internal_modules/roc_sndio/wav_sink.cpp
+++ b/src/internal_modules/roc_sndio/wav_sink.cpp
@@ -144,6 +144,10 @@ status::StatusCode WavSink::write(audio::Frame& frame) {
     return status::StatusOK;
 }
 
+status::StatusCode WavSink::flush() {
+    return status::StatusOK;
+}
+
 status::StatusCode WavSink::open_(const char* path) {
     if (output_file_) {
         roc_panic("wav sink: already opened");

--- a/src/internal_modules/roc_sndio/wav_sink.h
+++ b/src/internal_modules/roc_sndio/wav_sink.h
@@ -66,6 +66,9 @@ public:
     //! Write frame.
     virtual ROC_ATTR_NODISCARD status::StatusCode write(audio::Frame& frame);
 
+    //! Flush buffered data, if any.
+    virtual ROC_ATTR_NODISCARD status::StatusCode flush();
+
 private:
     status::StatusCode open_(const char* path);
     status::StatusCode close_();

--- a/src/tests/roc_pipeline/test_helpers/mock_sink.h
+++ b/src/tests/roc_pipeline/test_helpers/mock_sink.h
@@ -79,6 +79,10 @@ public:
         return status::StatusOK;
     }
 
+    virtual ROC_ATTR_NODISCARD status::StatusCode flush() {
+        return status::StatusOK;
+    }
+
     void expect_frames(size_t total) {
         UNSIGNED_LONGS_EQUAL(total, n_frames_);
     }

--- a/src/tests/roc_sndio/test_helpers/mock_sink.h
+++ b/src/tests/roc_sndio/test_helpers/mock_sink.h
@@ -86,6 +86,10 @@ public:
         }
     }
 
+    virtual ROC_ATTR_NODISCARD status::StatusCode flush() {
+        return status::StatusOK;
+    }
+
 private:
     enum { MaxSz = 256 * 1024 };
 


### PR DESCRIPTION
Fixes #703 
- Added `virtual ROC_ATTR_NODISCARD status::StatusCode flush()=0` pure virtual function in `sndio::ISink`.
- Added this method to all ISink implementations.
- Implementations that don't use buffereing are no-op.
- For SoxSink, flush() sends the buffered samples to disk.
- sndio::Pump invokes `flush()` when it exits from `run()`.