### PR TITLE
Improve peak jitter calculations

### DIFF
--- a/src/internal_modules/roc_audio/jitter_meter.cpp
+++ b/src/internal_modules/roc_audio/jitter_meter.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2024 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_audio/jitter_meter.h"
+#include "roc_core/panic.h"
+
+namespace roc {
+namespace audio {
+
+bool JitterMeterConfig::deduce_defaults(audio::LatencyTunerProfile latency_profile) {
+    if (jitter_window == 0) {
+        if (latency_profile == audio::LatencyTunerProfile_Responsive) {
+            jitter_window = 10000;
+        } else {
+            jitter_window = 30000;
+        }
+    }
+
+    if (peak_quantile_window == 0) {
+        peak_quantile_window = jitter_window / 5;
+    }
+
+    if (envelope_resistance_coeff == 0) {
+        if (latency_profile == audio::LatencyTunerProfile_Responsive) {
+            envelope_resistance_coeff = 0.05;
+        } else {
+            envelope_resistance_coeff = 0.1;
+        }
+    }
+
+    return true;
+}
+
+JitterMeter::JitterMeter(const JitterMeterConfig& config, core::IArena& arena)
+    : config_(config)
+    , jitter_window_(arena, config.jitter_window)
+    , smooth_jitter_window_(arena, config.envelope_smoothing_window_len)
+    , envelope_window_(arena, config.peak_quantile_window, config.peak_quantile_coeff)
+    , peak_window_(arena, config.jitter_window)
+    , capacitor_charge_(0)
+    , capacitor_discharge_resistance_(0)
+    , capacitor_discharge_iteration_(0) {
+}
+
+const JitterMetrics& JitterMeter::metrics() const {
+    return metrics_;
+}
+
+void JitterMeter::update_jitter(const core::nanoseconds_t jitter) {
+    // Moving average of jitter.
+    jitter_window_.add(jitter);
+
+    // Update current value of jitter envelope based on current value of jitter.
+    // Envelope is computed based on smoothed jitter + a leaky peak detector.
+    smooth_jitter_window_.add(jitter);
+    const core::nanoseconds_t jitter_envelope =
+        update_envelope_(smooth_jitter_window_.mov_max(), jitter_window_.mov_avg());
+
+    // Quantile of envelope.
+    envelope_window_.add(jitter_envelope);
+    // Moving maximum of quantile of envelope.
+    peak_window_.add(envelope_window_.mov_quantile());
+
+    metrics_.mean_jitter = jitter_window_.mov_avg();
+    metrics_.peak_jitter = peak_window_.mov_max();
+    metrics_.curr_jitter = jitter;
+    metrics_.curr_envelope = jitter_envelope;
+}
+
+// This function calculates jitter envelope using a model of a leaky peak detector.
+//
+// The quantile of jitter envelope is used as the value for `peak_jitter` metric.
+// LatencyTuner selects target latency based on its value. We want find lowest
+// possible peak jitter and target latency that are safe (don't cause disruptions).
+//
+// The function tries to achieve two goals:
+//
+//  - The quantile of envelope (e.g. 90% of values) should be above regular repeating
+//    spikes, typical for wireless networks, and should ignore occasional exceptions
+//    if they're not too high and not too frequent.
+//
+//  - The quantile of envelope should be however increased if occasional spike is
+//    really high, which is often a predictor of increasing network load
+//    (i.e. if spike is abnormally high, chances are that more high spikes follows).
+//
+// A leaky peak detector takes immediate peaks and mimicking a leakage process when
+// immediate values of jitter are lower than stored one. Without it, spikes would be
+// too thin to be reliably detected by quantile.
+//
+// Typical jitter envelope before applying capacitor:
+//
+//   ------------------------------------- maximum (too high)
+//     |╲
+//     ||          |╲        |╲
+//   --||----------||--------||----------- quantile (too low)
+//   __||______|╲__||__|╲____||__|╲____
+//
+// And after applying capacitor:
+//
+//     |╲_
+//   --|  |_-------|╲_-------|╲----------- quantile (good)
+//     |    ╲      |  ╲_     |  ╲_
+//   __|     ╲_|╲__|    ╲____|    ╲____
+//
+core::nanoseconds_t JitterMeter::update_envelope_(const core::nanoseconds_t cur_jitter,
+                                                  const core::nanoseconds_t avg_jitter) {
+    // `capacitor_charge_` represents current envelope value.
+    // Each step we either instantly re-charge capacitor if we see a peak, or slowly
+    // discharge it until it reaches zero or we see next peek.
+
+    if (capacitor_charge_ < cur_jitter) {
+        // If current jitter is higher than capacitor charge, instantly re-charge
+        // capacitor. The charge is set to the jitter value, and the resistance to
+        // discharging is proportional to the value of the jitter related to average.
+        //
+        // Peaks that are significantly higher than average cause very slow discharging,
+        // and hence have bigger impact on the envelope's quantile.
+        //
+        // Peaks that are not so high discharge quicker, but if they are frequent enough,
+        // capacitor value is constantly re-charged and keeps high. Hence, frequent peeks
+        // also have bigger impact on the envelope's quantile.
+        //
+        // Peaks that are neither high nor frequent have small impact on the quantile.
+        capacitor_charge_ = cur_jitter;
+        capacitor_discharge_resistance_ = std::pow((double)cur_jitter / avg_jitter,
+                                                   config_.envelope_resistance_exponent)
+            * config_.envelope_resistance_coeff;
+        capacitor_discharge_iteration_ = 0;
+    } else if (capacitor_charge_ > 0) {
+        // No peak detected, continue discharging (exponentially).
+        capacitor_charge_ =
+            core::nanoseconds_t(capacitor_charge_
+                                * std::exp(-capacitor_discharge_iteration_
+                                           / capacitor_discharge_resistance_));
+        capacitor_discharge_iteration_++;
+    }
+
+    if (capacitor_charge_ < 0) {
+        // Fully discharged. Normally doesn't happen.
+        capacitor_charge_ = 0;
+    }
+
+    return capacitor_charge_;
+}
+
+} // namespace audio
+} // namespace roc

--- a/src/internal_modules/roc_audio/jitter_meter.h
+++ b/src/internal_modules/roc_audio/jitter_meter.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2024 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_audio/jitter_meter.h
+//! @brief Jitter metrics calculator.
+
+#ifndef ROC_AUDIO_JITTER_METER_H_
+#define ROC_AUDIO_JITTER_METER_H_
+
+#include "roc_audio/latency_config.h"
+#include "roc_core/iarena.h"
+#include "roc_core/noncopyable.h"
+#include "roc_core/time.h"
+#include "roc_stat/mov_aggregate.h"
+#include "roc_stat/mov_quantile.h"
+
+namespace roc {
+namespace audio {
+
+//! Jitter meter parameters.
+//!
+//! Mean jitter is calculated as moving average of last `jitter_window` packets.
+//!
+//! Peak jitter calculation is performed in several steps:
+//!
+//!  1. Calculate jitter envelope - a curve that outlines jitter extremes.
+//!     Envelope calculation is based on a smoothing window
+//!     (`envelope_smoothing_window_len`) and a peak detector with capacitor
+//!     (`envelope_resistance_exponent`, `envelope_resistance_coeff`).
+//!
+//!  2. Calculate moving quantile of the envelope - a line above certain percentage
+//!     of the envelope values across moving window (`peak_quantile_coeff`,
+//!     `peak_quantile_window`).
+//!
+//!  3. Calculate moving maximum of the envelope's quantile across last `jitter_window`
+//!     samples. This is the resulting peak jitter.
+struct JitterMeterConfig {
+    //! Number of packets for calculating long-term jitter sliding statistics.
+    //! @remarks
+    //!  Increase this value if you want slower and smoother reaction.
+    //!  Peak jitter is not decreased until jitter envelope is low enough
+    //!  during this window.
+    //! @note
+    //!  Default value is about a few minutes.
+    size_t jitter_window;
+
+    //! Number of packets in small smoothing window to calculate jitter envelope.
+    //! @remarks
+    //!  The larger is this value, the rougher is jitter envelope.
+    //! @note
+    //!  Default value is a few packets.
+    size_t envelope_smoothing_window_len;
+
+    //! Exponent coefficient of capacitor resistance used in jitter envelope.
+    //! @note
+    //!  Capacitor discharge resistance is (peak ^ exp) * coeff, where `peak` is
+    //!  the jitter peak size relative to the average jitter, `exp` is
+    //!  `envelope_resistance_exponent`, and `coeff` is `envelope_resistance_coeff`.
+    //! @remarks
+    //!  Increase this value to make impact to the peak jitter of high spikes much
+    //!  stronger than impact of low spikes.
+    double envelope_resistance_exponent;
+
+    //! Linear coefficient of capacitor resistance used in jitter envelope.
+    //! @note
+    //!  Capacitor discharge resistance is (peak ^ exp) * coeff, where `peak` is
+    //!  the jitter peak size relative to the average jitter, `exp` is
+    //!  `envelope_resistance_exponent`, and `coeff` is `envelope_resistance_coeff`.
+    //! @remarks
+    //!  Increase this value to make impact to the peak jitter of frequent spikes
+    //!  stronger than impact of rare spikes.
+    double envelope_resistance_coeff;
+
+    //! Number of packets for calculating envelope quantile.
+    //! @remarks
+    //!  This window size is used to calculate moving quantile of the envelope.
+    //! @note
+    //!  This value is the compromise between reaction speed to the increased
+    //!  jitter and ability to distinguish rare spikes from frequent ones.
+    //!  If you increase this value, we can detect and cut out more spikes that
+    //!  are harmless, but we react to the relevant spikes a bit slower.
+    size_t peak_quantile_window;
+
+    //! Coefficient of envelope quantile from 0 to 1.
+    //! @remarks
+    //!  Defines percentage of the envelope that we want to cut out.
+    //! @note
+    //!  E.g. value 0.9 means that we want to draw a line that is above 90%
+    //!  of all envelope values across the quantile window.
+    double peak_quantile_coeff;
+
+    JitterMeterConfig()
+        : jitter_window(0)
+        , envelope_smoothing_window_len(10)
+        , envelope_resistance_exponent(6)
+        , envelope_resistance_coeff(0)
+        , peak_quantile_window(0)
+        , peak_quantile_coeff(0.90) {
+    }
+
+    //! Automatically fill missing settings.
+    ROC_ATTR_NODISCARD bool deduce_defaults(audio::LatencyTunerProfile latency_profile);
+};
+
+//! Jitter metrics.
+struct JitterMetrics {
+    //! Moving average of the jitter.
+    core::nanoseconds_t mean_jitter;
+
+    //! Moving peak value of the jitter.
+    //! @remarks
+    //!  This metric is similar to moving maximum, but excludes short rate spikes
+    //!  that are considered harmless.
+    core::nanoseconds_t peak_jitter;
+
+    //! Last jitter value.
+    core::nanoseconds_t curr_jitter;
+
+    //! Last jitter envelope value.
+    core::nanoseconds_t curr_envelope;
+
+    JitterMetrics()
+        : mean_jitter(0)
+        , peak_jitter(0)
+        , curr_jitter(0)
+        , curr_envelope(0) {
+    }
+};
+
+//! Jitter metrics calculator.
+class JitterMeter : public core::NonCopyable<JitterMeter> {
+public:
+    //! Initialize.
+    JitterMeter(const JitterMeterConfig& config, core::IArena& arena);
+
+    //! Get updated jitter metrics.
+    const JitterMetrics& metrics() const;
+
+    //! Update jitter metrics based on the jitter value for newly received packet.
+    void update_jitter(core::nanoseconds_t jitter);
+
+private:
+    core::nanoseconds_t update_envelope_(core::nanoseconds_t cur_jitter,
+                                         core::nanoseconds_t avg_jitter);
+
+    const JitterMeterConfig config_;
+
+    JitterMetrics metrics_;
+
+    stat::MovAggregate<core::nanoseconds_t> jitter_window_;
+    stat::MovAggregate<core::nanoseconds_t> smooth_jitter_window_;
+    stat::MovQuantile<core::nanoseconds_t> envelope_window_;
+    stat::MovAggregate<core::nanoseconds_t> peak_window_;
+
+    core::nanoseconds_t capacitor_charge_;
+    double capacitor_discharge_resistance_;
+    double capacitor_discharge_iteration_;
+};
+
+} // namespace audio
+} // namespace roc
+
+#endif // ROC_AUDIO_JITTER_METER_H_

--- a/src/internal_modules/roc_audio/latency_tuner.h
+++ b/src/internal_modules/roc_audio/latency_tuner.h
@@ -90,7 +90,7 @@ private:
     bool check_actual_latency_(packet::stream_timestamp_diff_t latency);
     void compute_scaling_(packet::stream_timestamp_diff_t latency);
 
-    void update_target_latency_(core::nanoseconds_t max_jitter_ns,
+    void update_target_latency_(core::nanoseconds_t peak_jitter_ns,
                                 core::nanoseconds_t mean_jitter_ns,
                                 core::nanoseconds_t fec_block_ns);
     void try_decrease_latency_(core::nanoseconds_t estimate,

--- a/src/internal_modules/roc_packet/ilink_meter.h
+++ b/src/internal_modules/roc_packet/ilink_meter.h
@@ -57,27 +57,21 @@ struct LinkMetrics {
     //!  Calculated by rtp::LinkMeter on receiver, reported via RTCP to sender.
     int64_t lost_packets;
 
-    //! Estimated interarrival jitter.
+    //! Average interarrival jitter.
     //! An estimate of the statistical variance of the RTP data packet interarrival time.
     //! Calculated based on a sliding window.
     //! @note
     //!  This value is calculated on sliding window on a receiver side and sender
     //!  side gets this value via RTCP.
-    core::nanoseconds_t jitter;
+    core::nanoseconds_t mean_jitter;
 
-    //! Running max of jitter.
+    //! Peak interarrival jitter.
+    //! An estimate of the maximum jitter, excluding short small spikes.
     //! Calculated based on a sliding window.
     //! @note
     //!  Available only on receiver.
     //!  Calculated by rtp::LinkMeter.
-    core::nanoseconds_t max_jitter;
-
-    //! Running min of jitter.
-    //! Calculated based on a sliding window.
-    //! @note
-    //!  Available only on receiver.
-    //!  Calculated by rtp::LinkMeter.
-    core::nanoseconds_t min_jitter;
+    core::nanoseconds_t peak_jitter;
 
     //! Estimated round-trip time between sender and receiver.
     //! Calculated based on NTP-like timestamp exchange implemented by RTCP protocol.
@@ -91,9 +85,8 @@ struct LinkMetrics {
         , ext_last_seqnum(0)
         , expected_packets(0)
         , lost_packets(0)
-        , jitter(0)
-        , max_jitter(0)
-        , min_jitter(0)
+        , mean_jitter(0)
+        , peak_jitter(0)
         , rtt(0) {
     }
 };

--- a/src/internal_modules/roc_pipeline/config.cpp
+++ b/src/internal_modules/roc_pipeline/config.cpp
@@ -29,10 +29,6 @@ bool SenderSinkConfig::deduce_defaults(audio::ProcessorMap& processor_map) {
         return false;
     }
 
-    if (!link_meter.deduce_defaults(latency.tuner_profile)) {
-        return false;
-    }
-
     if (!freq_est.deduce_defaults(latency.tuner_profile)) {
         return false;
     }
@@ -82,7 +78,7 @@ bool ReceiverSessionConfig::deduce_defaults(audio::ProcessorMap& processor_map) 
         return false;
     }
 
-    if (!link_meter.deduce_defaults(latency.tuner_profile)) {
+    if (!jitter_meter.deduce_defaults(latency.tuner_profile)) {
         return false;
     }
 

--- a/src/internal_modules/roc_pipeline/config.h
+++ b/src/internal_modules/roc_pipeline/config.h
@@ -14,6 +14,7 @@
 
 #include "roc_address/protocol.h"
 #include "roc_audio/feedback_monitor.h"
+#include "roc_audio/jitter_meter.h"
 #include "roc_audio/latency_config.h"
 #include "roc_audio/plc_config.h"
 #include "roc_audio/profiler.h"
@@ -31,7 +32,6 @@
 #include "roc_pipeline/pipeline_loop.h"
 #include "roc_rtcp/config.h"
 #include "roc_rtp/filter.h"
-#include "roc_rtp/link_meter.h"
 
 namespace roc {
 namespace pipeline {
@@ -83,9 +83,6 @@ struct SenderSinkConfig {
 
     //! Latency parameters.
     audio::LatencyConfig latency;
-
-    //! Link meter parameters.
-    rtp::LinkMeterConfig link_meter;
 
     //! Freq estimator parameters.
     audio::FreqEstimatorConfig freq_est;
@@ -180,8 +177,8 @@ struct ReceiverSessionConfig {
     //! Latency parameters.
     audio::LatencyConfig latency;
 
-    //! Link meter parameters.
-    rtp::LinkMeterConfig link_meter;
+    //! Jitter meter parameters.
+    audio::JitterMeterConfig jitter_meter;
 
     //! Freq estimator parameters.
     audio::FreqEstimatorConfig freq_est;

--- a/src/internal_modules/roc_pipeline/receiver_session.cpp
+++ b/src/internal_modules/roc_pipeline/receiver_session.cpp
@@ -54,7 +54,7 @@ ReceiverSession::ReceiverSession(const ReceiverSessionConfig& session_config,
     pkt_writer = source_queue_.get();
 
     source_meter_.reset(new (source_meter_) rtp::LinkMeter(
-        *pkt_writer, session_config.link_meter, encoding_map, arena, dumper_));
+        *pkt_writer, session_config.jitter_meter, encoding_map, arena, dumper_));
     if ((init_status_ = source_meter_->init_status()) != status::StatusOK) {
         return;
     }
@@ -109,7 +109,8 @@ ReceiverSession::ReceiverSession(const ReceiverSessionConfig& session_config,
         repair_pkt_writer = repair_queue_.get();
 
         repair_meter_.reset(new (repair_meter_) rtp::LinkMeter(
-            *repair_pkt_writer, session_config.link_meter, encoding_map, arena, dumper_));
+            *repair_pkt_writer, session_config.jitter_meter, encoding_map, arena,
+            dumper_));
         if ((init_status_ = repair_meter_->init_status()) != status::StatusOK) {
             return;
         }
@@ -385,7 +386,7 @@ void ReceiverSession::generate_reports(const char* report_cname,
         report.ext_last_seqnum = link_metrics.ext_last_seqnum;
         report.packet_count = link_metrics.expected_packets;
         report.cum_loss = link_metrics.lost_packets;
-        report.jitter = link_metrics.jitter;
+        report.jitter = link_metrics.mean_jitter;
         report.niq_latency = latency_metrics.niq_latency;
         report.niq_stalling = latency_metrics.niq_stalling;
         report.e2e_latency = latency_metrics.e2e_latency;
@@ -410,7 +411,7 @@ void ReceiverSession::generate_reports(const char* report_cname,
         report.ext_last_seqnum = link_metrics.ext_last_seqnum;
         report.packet_count = link_metrics.expected_packets;
         report.cum_loss = link_metrics.lost_packets;
-        report.jitter = link_metrics.jitter;
+        report.jitter = link_metrics.mean_jitter;
 
         reports++;
         n_reports--;

--- a/src/internal_modules/roc_pipeline/sender_session.cpp
+++ b/src/internal_modules/roc_pipeline/sender_session.cpp
@@ -404,7 +404,7 @@ SenderSession::notify_send_stream(packet::stream_source_t recv_source_id,
         link_metrics.ext_last_seqnum = recv_report.ext_last_seqnum;
         link_metrics.expected_packets = recv_report.packet_count;
         link_metrics.lost_packets = recv_report.cum_loss;
-        link_metrics.jitter = recv_report.jitter;
+        link_metrics.mean_jitter = recv_report.jitter;
         link_metrics.rtt = recv_report.rtt;
 
         feedback_monitor_->process_feedback(recv_source_id, latency_metrics,

--- a/src/internal_modules/roc_stat/mov_aggregate.h
+++ b/src/internal_modules/roc_stat/mov_aggregate.h
@@ -7,7 +7,7 @@
  */
 
 //! @file roc_stat/mov_aggregate.h
-//! @brief Rolling window moving average, variance, minimum, and maximum.
+//! @brief Rolling window average, variance, minimum, maximum.
 
 #ifndef ROC_STAT_MOV_AGGREGATE_H_
 #define ROC_STAT_MOV_AGGREGATE_H_
@@ -20,7 +20,7 @@
 namespace roc {
 namespace stat {
 
-//! Rolling window moving average, variance, minimum, and maximum.
+//! Rolling window average, variance, minimum, maximum.
 //!
 //! Efficiently implements moving average and variance based on Welford's method:
 //!  - https://www.johndcook.com/blog/standard_deviation (incremental)

--- a/src/internal_modules/roc_stat/mov_histogram.h
+++ b/src/internal_modules/roc_stat/mov_histogram.h
@@ -7,7 +7,7 @@
  */
 
 //! @file roc_stat/mov_histogram.h
-//! @brief Rolling window moving histogram.
+//! @brief Rolling window histogram.
 
 #ifndef ROC_STAT_MOV_HISTOGRAM_H_
 #define ROC_STAT_MOV_HISTOGRAM_H_
@@ -99,11 +99,11 @@ public:
     T mov_quantile(const double quantile) const {
         roc_panic_if(!valid_);
 
-        T cap;
+        T cap = T(0);
         size_t count = 0;
 
         for (size_t bin_index = 0; bin_index < num_bins_; bin_index++) {
-            cap = value_range_min_ + bin_width_ * (bin_index + 1);
+            cap = value_range_min_ + T(bin_width_) * T(bin_index + 1);
             count += bins_[bin_index];
 
             const double ratio = (double)count / ring_buffer_.size();

--- a/src/internal_modules/roc_stat/mov_quantile.h
+++ b/src/internal_modules/roc_stat/mov_quantile.h
@@ -7,7 +7,7 @@
  */
 
 //! @file roc_stat/mov_quantile.h
-//! @brief Rolling window moving quantile.
+//! @brief Rolling window quantile.
 
 #ifndef ROC_STAT_MOV_QUANTILE_H_
 #define ROC_STAT_MOV_QUANTILE_H_
@@ -19,7 +19,7 @@
 namespace roc {
 namespace stat {
 
-//! Rolling window moving quantile.
+//! Rolling window quantile.
 //!
 //! Efficiently implements moving quantile using partition heap based on approach
 //! described in https://aakinshin.net/posts/partitioning-heaps-quantile-estimator/.

--- a/src/public_api/src/adapters.cpp
+++ b/src/public_api/src/adapters.cpp
@@ -805,8 +805,8 @@ void link_metrics_to_user(roc_connection_metrics& out, const packet::LinkMetrics
         out.rtt = (unsigned long long)in.rtt;
     }
 
-    if (in.jitter > 0) {
-        out.jitter = (unsigned long long)in.jitter;
+    if (in.mean_jitter > 0) {
+        out.jitter = (unsigned long long)in.mean_jitter;
     }
 
     if (in.expected_packets > 0) {

--- a/src/tests/roc_pipeline/test_helpers/control_writer.h
+++ b/src/tests/roc_pipeline/test_helpers/control_writer.h
@@ -97,7 +97,7 @@ public:
         rr_blk.set_ssrc(remote_source_);
         rr_blk.set_cum_loss(link_metrics_.lost_packets);
         rr_blk.set_last_seqnum(link_metrics_.ext_last_seqnum);
-        rr_blk.set_jitter(sample_spec.ns_2_stream_timestamp(link_metrics_.jitter));
+        rr_blk.set_jitter(sample_spec.ns_2_stream_timestamp(link_metrics_.mean_jitter));
         rr_blk.set_last_sr(ntp_ts);
         rr_blk.set_delay_last_sr(0);
 

--- a/src/tests/roc_pipeline/test_loopback_sink_2_source.cpp
+++ b/src/tests/roc_pipeline/test_loopback_sink_2_source.cpp
@@ -414,7 +414,7 @@ void check_metrics(ReceiverSlot& receiver,
     } else {
         CHECK(recv_party_metrics.link.lost_packets == 0);
     }
-    CHECK(recv_party_metrics.link.jitter > 0);
+    CHECK(recv_party_metrics.link.mean_jitter > 0);
 
     CHECK(recv_party_metrics.latency.niq_latency > 0);
     CHECK(recv_party_metrics.latency.niq_stalling >= 0);
@@ -450,7 +450,8 @@ void check_metrics(ReceiverSlot& receiver,
 
         UNSIGNED_LONGS_EQUAL(recv_party_metrics.link.lost_packets,
                              send_party_metrics.link.lost_packets);
-        CHECK(std::abs(recv_party_metrics.link.jitter - send_party_metrics.link.jitter)
+        CHECK(std::abs(recv_party_metrics.link.mean_jitter
+                       - send_party_metrics.link.mean_jitter)
               < 1 * core::Millisecond);
 
         DOUBLES_EQUAL(recv_party_metrics.latency.niq_latency,

--- a/src/tests/roc_pipeline/test_sender_sink.cpp
+++ b/src/tests/roc_pipeline/test_sender_sink.cpp
@@ -650,7 +650,7 @@ TEST(sender_sink, metrics_feedback) {
         link_metrics.ext_last_seqnum = seed * 200;
         link_metrics.expected_packets = (seed * 200) - (seed * 100) + 1;
         link_metrics.lost_packets = (int)seed * 40;
-        link_metrics.jitter = (int)seed * core::Millisecond * 50;
+        link_metrics.mean_jitter = (int)seed * core::Millisecond * 50;
 
         audio::LatencyMetrics latency_metrics;
         latency_metrics.niq_latency = (int)seed * core::Millisecond * 50;
@@ -688,8 +688,8 @@ TEST(sender_sink, metrics_feedback) {
                                  party_metrics[0].link.expected_packets);
             UNSIGNED_LONGS_EQUAL(link_metrics.lost_packets,
                                  party_metrics[0].link.lost_packets);
-            DOUBLES_EQUAL((double)link_metrics.jitter,
-                          (double)party_metrics[0].link.jitter, core::Nanosecond);
+            DOUBLES_EQUAL((double)link_metrics.mean_jitter,
+                          (double)party_metrics[0].link.mean_jitter, core::Nanosecond);
 
             DOUBLES_EQUAL((double)latency_metrics.niq_latency,
                           (double)party_metrics[0].latency.niq_latency,


### PR DESCRIPTION
gh-712

- Extract JitterMeter class.
- Remove `min_jitter` metric (it is almost always zero or very close to it).
- Replace `max_jitter` with `peak_jitter`, which is similar to maximum, but tries to exclude harmless spikes to reduce latency.

See comments in JitterMeter for details on the algorithm.

QA: https://github.com/roc-streaming/qa/tree/main/manual/20241011_gh688_adaptive_latency