### PR TITLE
Implement freelist class

### DIFF
--- a/src/internal_modules/roc_core/free_list.h
+++ b/src/internal_modules/roc_core/free_list.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2015 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_core/free_list.h
+//! @brief Intrusive doubly-linked list.
+
+#ifndef ROC_CORE_FREE_LIST_H_
+#define ROC_CORE_FREE_LIST_H_
+
+#include "roc_core/free_list_impl.h"
+#include "roc_core/free_list_node.h"
+#include "roc_core/noncopyable.h"
+#include "roc_core/ownership_policy.h"
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace core {
+
+//! A simple CAS-based lock-free free list
+//!
+//! @tparam T defines object type, it must inherit FreeListNode.
+//!
+//! @tparam OwnershipPolicy defines ownership policy which is used to acquire an
+//! element ownership when it's added to the list and release ownership when it's
+//! removed from the list.
+//!
+//! @tparam Node defines base class of list nodes. It is needed if FreeListNode is
+//! used with non-default tag.
+template <class T,
+          template <class TT> class OwnershipPolicy = RefCountedOwnership,
+          class Node = FreeListNode<> >
+class FreeList : public NonCopyable<> {
+public:
+    //! Pointer type.
+    //! @remarks
+    //!  either raw or smart pointer depending on the ownership policy.
+    typedef typename OwnershipPolicy<T>::Pointer Pointer;
+
+    //! Initialize empty list.
+    FreeList() {
+    }
+
+    //! Release ownership of containing objects.
+    ~FreeList() {
+        while (!is_empty()) {
+            unsafe_pop_front();
+        }
+    }
+
+    //! Get first list element.
+    //! @returns
+    //!  first element or NULL if list is empty.
+    Pointer front() const {
+        FreeListData* data = impl_.front();
+        return from_free_node_data_(data);
+    }
+
+    //! Prepend element to list.
+    //!
+    //! @remarks
+    //!  - prepends @p elem to list
+    //!  - acquires ownership of @p elem
+    //!
+    //! @pre
+    //!  @p elem should not be member of any list.
+    void push_front(T& elem) {
+        OwnershipPolicy<T>::acquire(elem);
+
+        FreeListData* data = to_free_node_data_(elem);
+        impl_.push_front(data);
+    }
+
+    //! Pop first element from list.
+    //!
+    //! @remarks
+    //!  - removes first element of list
+    //!  - releases ownership of removed element
+    //!
+    //! @pre
+    //!  the list should not be empty.
+    void try_pop_front() {
+        FreeListData* data = impl_.try_pop_front();
+        T* elem = from_free_node_data_(data);
+
+        OwnershipPolicy<T>::release(*elem);
+    }
+
+    //! Checks if list is empty
+    bool is_empty() {
+        return impl_.is_empty();
+    }
+
+private:
+    static FreeListData* to_free_node_data_(const T& elem) {
+        return static_cast<const Node&>(elem).list_data();
+    }
+
+    static T* from_free_node_data_(FreeListData* data) {
+        return static_cast<T*>(static_cast<Node*>(Node::list_node(data)));
+    }
+
+    void unsafe_pop_front() {
+        FreeListData* data = impl_.unsafe_pop_front();
+        T* elem = from_free_node_data_(data);
+
+        OwnershipPolicy<T>::release(*elem);
+    }
+
+    FreeListImpl impl_;
+};
+
+} // namespace core
+} // namespace roc
+
+#endif // ROC_CORE_FREE_LIST_H_

--- a/src/internal_modules/roc_core/free_list_impl.cpp
+++ b/src/internal_modules/roc_core/free_list_impl.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2015 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_core/free_list_impl.h"
+#include "roc_core/free_list_node.h"
+#include "roc_core/panic.h"
+#include "roc_core/target_libatomic_ops/roc_core/atomic_ops.h"
+
+namespace roc {
+namespace core {
+
+static const uint32_t SHOULD_BE_ON_FREELIST = 0x80000000;
+static const uint32_t REFS_MASK = 0x7FFFFFFF;
+static const uint32_t SUB_1 = 0xFFFFFFFF;
+static const uint32_t SUB_2 = 0xFFFFFFFE;
+
+FreeListImpl::FreeListImpl()
+    : head_(NULL) {
+}
+
+FreeListImpl::~FreeListImpl() {
+}
+
+FreeListData* FreeListImpl::front() const {
+    return head_;
+}
+
+bool FreeListImpl::is_empty() {
+    if (head_ == NULL)
+        return true;
+    return false;
+}
+
+FreeListData* FreeListImpl::unsafe_pop_front() {
+    if (head_ == NULL) {
+        return NULL;
+    }
+    FreeListData* node = head_;
+    head_ = node->next;
+    return node;
+}
+
+FreeListData* FreeListImpl::try_pop_front() {
+    FreeListData* current_head = AtomicOps::load_acquire(head_);
+    if (current_head == NULL) {
+        return NULL;
+    }
+    while (current_head != NULL) {
+        FreeListData* prev_head = current_head;
+        uint32_t refs = AtomicOps::load_relaxed(current_head->refs);
+        if ((refs & REFS_MASK) == 0
+            || !AtomicOps::compare_exchange_acq_rel(head_->refs, current_head->refs,
+                                                    refs)) {
+            current_head = AtomicOps::load_acquire(head_);
+            continue;
+        }
+        // Good, reference count has been incremented (it wasn't at zero), which means
+        // we can read the next and not worry about it changing between now and the time
+        // we do the CAS
+        FreeListData* next = AtomicOps::load_relaxed(current_head->next);
+        if (AtomicOps::compare_exchange_acq_rel(head_, current_head, next)) {
+            // Got the node. This means it was on the list, which means
+            // shouldBeOnFreeList must be false no matter the refcount (because
+            // nobody else knows it's been taken off yet, it can't have been put back on).
+            if (!((current_head->refs & SHOULD_BE_ON_FREELIST) == 0)) {
+                roc_panic("ABA problem");
+            }
+            // Decrease refcount twice, once for our ref, and once for the list's ref
+            AtomicOps::fetch_add_relaxed(current_head->refs, SUB_2);
+            return current_head;
+        }
+        // OK, the head must have changed on us, but we still need to decrease the
+        // refcount we increased
+        refs = AtomicOps::fetch_add_acquire(prev_head->refs, SUB_1);
+        if (refs == SHOULD_BE_ON_FREELIST + 1) {
+            add_knowing_refcount_is_zero_(prev_head);
+        }
+    }
+    return NULL;
+}
+
+void FreeListImpl::push_front(FreeListData* node) {
+    if (AtomicOps::fetch_add_release(node->refs, SHOULD_BE_ON_FREELIST) == 0) {
+        add_knowing_refcount_is_zero_(node);
+    }
+}
+
+void FreeListImpl::add_knowing_refcount_is_zero_(FreeListData* node) {
+    // Since the refcount is zero, and nobody can increase it once it's zero (except us,
+    // and we run only one copy of this method per node at a time, i.e. the single thread
+    // case), then we know we can safely change the next pointer of the node; however,
+    // once the refcount is back above zero, then other threads could increase it (happens
+    // under heavy contention, when the refcount goes to zero in between a load and a
+    // refcount increment of a node in try_get, then back up to something non-zero, then
+    // the refcount increment is done by the other thread) -- so, if the CAS to add the
+    // node to the actual list fails, decrease the refcount and leave the add operation to
+    // the next thread who puts the refcount back at zero (which could be us, hence the
+    // loop).
+    FreeListData* current_head = AtomicOps::load_relaxed(head_);
+    while (true) {
+        AtomicOps::store_relaxed(node->next, current_head);
+        AtomicOps::store_release(node->refs, static_cast<uint32_t>(1));
+        if (!AtomicOps::compare_exchange_release(head_, current_head, node)) {
+            // Hmm, the add failed, but we can only try again when the refcount goes back
+            // to zero
+            if (AtomicOps::fetch_add_release(node->refs, SHOULD_BE_ON_FREELIST - 1)
+                == 1) {
+                continue;
+            }
+        }
+        return;
+    }
+}
+} // namespace core
+} // namespace roc

--- a/src/internal_modules/roc_core/free_list_impl.h
+++ b/src/internal_modules/roc_core/free_list_impl.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_core/free_list_impl.h
+//! @brief TODO.
+
+#ifndef ROC_CORE_FREE_LIST_IMPL_H_
+#define ROC_CORE_FREE_LIST_IMPL_H_
+
+#include "roc_core/atomic.h"
+#include "roc_core/free_list_node.h"
+#include "roc_core/noncopyable.h"
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace core {
+//! A simple CAS-based lock-free free list. Not the fastest thing in the world under heavy
+//! contention, but simple and correct (assuming nodes are never freed until after the
+//! free list is destroyed), and fairly speedy under low contention. Implemented like a
+//! stack, but where node order doesn't matter (nodes are inserted out of order under
+//! contention)
+
+//! Credits:
+//! Based on the article by Cameron:
+//! https://moodycamel.com/blog/2014/solving-the-aba-problem-for-lock-free-free-lists.htm
+class FreeListImpl : public NonCopyable<> {
+public:
+    FreeListImpl();
+
+    ~FreeListImpl();
+    //! Try to remove first node and return.
+    FreeListData* try_pop_front();
+
+    //! Remove first element under the condition that the list is not being used by anyone
+    FreeListData* unsafe_pop_front();
+
+    //! Get first element of list, i.e., head
+    FreeListData* front() const;
+
+    //! Check if list is empty
+    bool is_empty();
+
+    //! Insert node into list.
+    void push_front(FreeListData* node);
+
+    //! Add node knowing that it is not part of a free list.
+    void add_knowing_refcount_is_zero_(FreeListData* node);
+
+private:
+    FreeListData* head_;
+};
+
+} // namespace core
+} // namespace roc
+
+#endif // ROC_CORE_FREE_LIST_IMPL_H_

--- a/src/internal_modules/roc_core/free_list_node.h
+++ b/src/internal_modules/roc_core/free_list_node.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_core/free_list_node.h
+//! @brief Free list node.
+
+#ifndef ROC_CORE_FREE_LIST_NODE_H_
+#define ROC_CORE_FREE_LIST_NODE_H_
+
+#include "roc_core/macro_helpers.h"
+#include "roc_core/noncopyable.h"
+#include "roc_core/panic.h"
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace core {
+
+//! Free list node internal data.
+struct FreeListData {
+    //! Next free list element.
+    FreeListData* next;
+
+    //! Reference counter for free list.
+    uint32_t refs;
+
+    FreeListData()
+        : next(NULL)
+        , refs(0) {
+    }
+};
+
+//! Base class for Free List element.
+//! @remarks
+//!  Object should inherit this class to be able to be a member of List.
+//!  Tag allows to inherit multiple copies of FreeListNode and include same
+//!  object into multiple lists.
+template <class Tag = void> class FreeListNode : public NonCopyable<FreeListNode<Tag> > {
+public:
+    ~FreeListNode() {
+    }
+    //! Get pointer to parent node from pointer to internal data.
+    static FreeListNode* list_node(FreeListData* data) {
+        return ROC_CONTAINER_OF(data, FreeListNode, free_list_data_);
+    }
+
+    //! Get pointer to internal data.
+    FreeListData* list_data() const {
+        return &free_list_data_;
+    }
+
+private:
+    mutable FreeListData free_list_data_;
+};
+
+} // namespace core
+} // namespace roc
+
+#endif // ROC_CORE_FREE_LIST_NODE_H_

--- a/src/tests/roc_core/test_free_list.cpp
+++ b/src/tests/roc_core/test_free_list.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2015 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <CppUTest/TestHarness.h>
+
+#include "roc_core/free_list.h"
+#include "roc_core/ref_counted.h"
+#include "roc_core/shared_ptr.h"
+
+namespace roc {
+namespace core {
+
+namespace {
+
+enum { NumObjects = 5 };
+
+struct Object : FreeListNode<> {};
+
+struct RefObject : RefCounted<RefObject, NoopAllocation>, FreeListNode<> {};
+
+} // namespace
+
+TEST_GROUP(free_list) {};
+
+TEST(free_list, empty_list) {
+    FreeList<Object, NoOwnership> list;
+    CHECK(list.front() == NULL);
+    CHECK(list.is_empty());
+}
+
+TEST(free_list, push_front) {
+    {
+        // push one element
+        Object objects[NumObjects];
+        FreeList<Object, NoOwnership> list;
+
+        list.push_front(objects[0]);
+        POINTERS_EQUAL(&objects[0], list.front());
+        CHECK(!list.is_empty());
+    }
+    { // push many elements
+        Object objects[NumObjects];
+        FreeList<Object, NoOwnership> list;
+
+        for (size_t i = 0; i < NumObjects; ++i) {
+            list.push_front(objects[i]);
+        }
+
+        POINTERS_EQUAL(&objects[NumObjects - 1], list.front());
+        CHECK(!list.is_empty());
+    }
+}
+
+TEST(free_list, try_pop_front) {
+    // with push_front
+    Object objects[NumObjects];
+    FreeList<Object, NoOwnership> list;
+    size_t size = 0;
+    for (size_t i = 0; i < NumObjects; ++i) {
+        list.push_front(objects[i]);
+        size++;
+    }
+
+    for (size_t i = 0; i < NumObjects; ++i) {
+        LONGS_EQUAL(NumObjects - i, size);
+        list.try_pop_front();
+        if (i != NumObjects - 1) {
+            POINTERS_EQUAL(&objects[NumObjects - i - 2], list.front());
+        }
+        size--;
+    }
+
+    CHECK(list.front() == NULL);
+}
+
+TEST(free_list, iteration) {
+    Object objects[NumObjects];
+    FreeList<Object, NoOwnership> list;
+
+    for (size_t i = 0; i < NumObjects; ++i) {
+        list.push_front(objects[i]);
+    }
+}
+
+TEST(free_list, ownership_operations) {
+    { // push_front
+        RefObject obj;
+        FreeList<RefObject, RefCountedOwnership> list;
+
+        LONGS_EQUAL(0, obj.getref());
+        list.push_front(obj);
+        LONGS_EQUAL(1, obj.getref());
+    }
+    { // pop_front
+        RefObject obj1;
+        RefObject obj2;
+
+        FreeList<RefObject, RefCountedOwnership> list;
+
+        list.push_front(obj1);
+        list.push_front(obj2);
+        LONGS_EQUAL(1, obj1.getref());
+        LONGS_EQUAL(1, obj2.getref());
+
+        list.try_pop_front();
+        LONGS_EQUAL(0, obj2.getref());
+        POINTERS_EQUAL(&obj1, list.front().get());
+
+        list.try_pop_front();
+        LONGS_EQUAL(0, obj1.getref());
+    }
+}
+
+TEST(free_list, ownership_destructor) {
+    RefObject obj;
+    {
+        FreeList<RefObject, RefCountedOwnership> list;
+
+        list.push_front(obj);
+
+        LONGS_EQUAL(1, obj.getref());
+    }
+
+    LONGS_EQUAL(0, obj.getref());
+}
+
+TEST(free_list, shared_pointers) {
+    RefObject obj;
+    FreeList<RefObject, RefCountedOwnership> list;
+
+    list.push_front(obj);
+
+    POINTERS_EQUAL(&obj, list.front().get());
+
+    LONGS_EQUAL(2, list.front()->getref());
+}
+} // namespace core
+
+} // namespace roc


### PR DESCRIPTION
Hey @gavv,

the PR is not ready yet (obvious lack of tests, still some work on the code) but I wanted to double check whether this goes in the direction you envisioned.
Especially regarding the very limited functionality of the `FreeList`.
Another thing: Right now I use the default memory order coming from the `Atomic` templates (sequentially consistent ordering). This should work in principle, but deviates from what is suggested in the [article](https://moodycamel.com/blog/2014/solving-the-aba-problem-for-lock-free-free-lists.htm) you linked.
To my understanding, using the stricter memory ordering might introduce some performance issues under heavy contention.
Since a more fine grained memory order control is possible with the `AtomicOps`, I was wondering what you think about this.

#734