### PR TITLE
Split MovAggregate into MovAvgStd and MovMinMax

### DIFF
--- a/src/internal_modules/roc_audio/jitter_meter.h
+++ b/src/internal_modules/roc_audio/jitter_meter.h
@@ -16,7 +16,8 @@
 #include "roc_core/iarena.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/time.h"
-#include "roc_stat/mov_aggregate.h"
+#include "roc_stat/mov_avg_std.h"
+#include "roc_stat/mov_min_max.h"
 #include "roc_stat/mov_quantile.h"
 
 namespace roc {
@@ -152,10 +153,10 @@ private:
 
     JitterMetrics metrics_;
 
-    stat::MovAggregate<core::nanoseconds_t> jitter_window_;
-    stat::MovAggregate<core::nanoseconds_t> smooth_jitter_window_;
+    stat::MovAvgStd<core::nanoseconds_t> jitter_window_;
+    stat::MovMinMax<core::nanoseconds_t> smooth_jitter_window_;
     stat::MovQuantile<core::nanoseconds_t> envelope_window_;
-    stat::MovAggregate<core::nanoseconds_t> peak_window_;
+    stat::MovMinMax<core::nanoseconds_t> peak_window_;
 
     core::nanoseconds_t capacitor_charge_;
     double capacitor_discharge_resistance_;

--- a/src/internal_modules/roc_stat/mov_avg_std.h
+++ b/src/internal_modules/roc_stat/mov_avg_std.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2024 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_stat/mov_avg_std.h
+//! @brief Rolling window average and standard deviation.
+
+#ifndef ROC_STAT_MOV_AVG_STD_H_
+#define ROC_STAT_MOV_AVG_STD_H_
+
+#include "roc_core/array.h"
+#include "roc_core/iarena.h"
+#include "roc_core/panic.h"
+
+namespace roc {
+namespace stat {
+
+//! Rolling window average and standard deviation.
+//!
+//! Efficiently implements moving average and variance based on Welford's method:
+//!  - https://www.johndcook.com/blog/standard_deviation (incremental)
+//!  - https://stackoverflow.com/a/6664212/3169754 (rolling window)
+//!
+//! @tparam T defines a sample type.
+template <typename T> class MovAvgStd {
+public:
+    //! Initialize.
+    MovAvgStd(core::IArena& arena, const size_t win_len)
+        : win_len_(win_len)
+        , buffer_(arena)
+        , buffer_i_(0)
+        , movmean_(0)
+        , movvar_(0)
+        , full_(false)
+        , valid_(false) {
+        if (win_len == 0) {
+            roc_panic("mov avg std: window length must be greater than 0");
+        }
+
+        if (!buffer_.resize(win_len)) {
+            return;
+        }
+
+        valid_ = true;
+    }
+
+    //! Check that initial allocation succeeded.
+    bool is_valid() const {
+        return valid_;
+    }
+
+    //! Check if the window is fully filled.
+    size_t is_full() const {
+        return full_;
+    }
+
+    //! Get moving average.
+    //! @note
+    //!  Has O(1) complexity.
+    T mov_avg() const {
+        roc_panic_if(!valid_);
+
+        T ret;
+        double_2_t_(movmean_, ret);
+        return ret;
+    }
+
+    //! Get moving variance.
+    //! @note
+    //!  Has O(1) complexity.
+    T mov_var() const {
+        roc_panic_if(!valid_);
+
+        T ret;
+        double_2_t_(movvar_ > 0 ? movvar_ : 0, ret);
+        return ret;
+    }
+
+    //! Get moving standard deviation.
+    //! @note
+    //!  Has O(1) complexity.
+    T mov_std() const {
+        roc_panic_if(!valid_);
+
+        T ret;
+        double_2_t_(sqrt(movvar_ > 0 ? movvar_ : 0), ret);
+        return ret;
+    }
+
+    //! Shift rolling window by one sample x.
+    //! @note
+    //!  Has O(1) complexity.
+    void add(const T& x) {
+        roc_panic_if(!valid_);
+
+        const T x_old = buffer_[buffer_i_];
+        buffer_[buffer_i_] = x;
+
+        update_sums_(x, x_old);
+
+        buffer_i_++;
+        if (buffer_i_ == win_len_) {
+            buffer_i_ = 0;
+            full_ = true;
+        }
+    }
+
+private:
+    // Update moving average and moving variance.
+    void update_sums_(const T& x, const T x_old) {
+        if (full_) {
+            // Since window is full, use rolling window adaption of Welford's method.
+            // Operations are reordered to avoid overflows.
+            const double movmean_old = movmean_;
+            movmean_ += double(x - x_old) / win_len_;
+            movvar_ += ((x - movmean_) + (x_old - movmean_old)) / win_len_ * (x - x_old);
+        } else {
+            // Until window is full, use original Welford's method.
+            // Operations are reordered to avoid overflows.
+            const double movmean_old = movmean_;
+            const double n = buffer_i_;
+            movmean_ += (x - movmean_) / (n + 1);
+            if (n > 0) {
+                movvar_ =
+                    (movvar_ + (x - movmean_old) / n * (x - movmean_)) * (n / (n + 1));
+            }
+        }
+    }
+
+    // Convert double to sample type.
+    // If sample type is integer, use round(), otherwise regular cast.
+    template <class TT> void double_2_t_(double in, TT& out) const {
+        out = (TT)round(in);
+    }
+    void double_2_t_(double in, float& out) const {
+        out = (float)in;
+    }
+    void double_2_t_(double in, double& out) const {
+        out = in;
+    }
+
+    const size_t win_len_;
+
+    core::Array<T> buffer_;
+    size_t buffer_i_;
+
+    double movmean_;
+    double movvar_;
+
+    bool full_;
+
+    bool valid_;
+};
+
+} // namespace stat
+} // namespace roc
+
+#endif // ROC_STAT_MOV_AVG_STD_H_

--- a/src/internal_modules/roc_stat/mov_min_max.h
+++ b/src/internal_modules/roc_stat/mov_min_max.h
@@ -90,14 +90,14 @@ public:
         const T x_old = buffer_[buffer_i_];
         buffer_[buffer_i_] = x;
 
+        slide_max_(x, x_old);
+        slide_min_(x, x_old);
+
         buffer_i_++;
         if (buffer_i_ == win_len_) {
             buffer_i_ = 0;
             full_ = true;
         }
-
-        slide_max_(x, x_old);
-        slide_min_(x, x_old);
     }
 
 private:
@@ -109,7 +109,7 @@ private:
             queue_max_.push_back(x);
             curr_max_ = x;
         } else {
-            if (queue_max_.front() == x_old) {
+            if (queue_max_.front() == x_old && full_) {
                 queue_max_.pop_front();
                 curr_max_ = queue_max_.is_empty() ? x : queue_max_.front();
             }
@@ -131,7 +131,7 @@ private:
             queue_min_.push_back(x);
             curr_min_ = x;
         } else {
-            if (queue_min_.front() == x_old) {
+            if (queue_min_.front() == x_old && full_) {
                 queue_min_.pop_front();
                 curr_min_ = queue_min_.is_empty() ? x : queue_min_.front();
             }

--- a/src/tests/roc_pipeline/test_receiver_source.cpp
+++ b/src/tests/roc_pipeline/test_receiver_source.cpp
@@ -19,7 +19,7 @@
 #include "roc_core/time.h"
 #include "roc_pipeline/receiver_source.h"
 #include "roc_rtp/encoding_map.h"
-#include "roc_stat/mov_aggregate.h"
+#include "roc_stat/mov_min_max.h"
 
 // This file contains tests for ReceiverSource. ReceiverSource can be seen as a big
 // composite processor (consisting of chained smaller processors) that transforms
@@ -3437,7 +3437,7 @@ TEST(receiver_source, adaptive_latency_increase) {
     packet_writer.set_jitter(jitter - tolerance, jitter + tolerance);
 
     // wait until we reach stable latency
-    stat::MovAggregate<core::nanoseconds_t> latency_hist(arena, stabilization_window);
+    stat::MovMinMax<core::nanoseconds_t> latency_hist(arena, stabilization_window);
     CHECK(latency_hist.is_valid());
 
     for (;;) {
@@ -3515,7 +3515,7 @@ TEST(receiver_source, adaptive_latency_decrease) {
     packet_writer.set_jitter(jitter - tolerance, jitter + tolerance);
 
     // wait until we reach stable latency
-    stat::MovAggregate<core::nanoseconds_t> latency_hist(arena, stabilization_window);
+    stat::MovMinMax<core::nanoseconds_t> latency_hist(arena, stabilization_window);
     CHECK(latency_hist.is_valid());
 
     for (;;) {

--- a/src/tests/roc_stat/test_mov_avg_std.cpp
+++ b/src/tests/roc_stat/test_mov_avg_std.cpp
@@ -6,27 +6,30 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <CppUTest/TestHarness.h>
+#include "test_harness.h"
 
 #include "roc_core/fast_random.h"
 #include "roc_core/heap_arena.h"
 #include "roc_core/macro_helpers.h"
-#include "roc_stat/mov_aggregate.h"
+#include "roc_stat/mov_avg_std.h"
 
 namespace roc {
 namespace stat {
 
-TEST_GROUP(mov_aggregate) {
+TEST_GROUP(mov_avg_std) {
     core::HeapArena arena;
 };
 
-TEST(mov_aggregate, single_pass) {
+TEST(mov_avg_std, single_pass) {
     const size_t n = 10;
-    int64_t x[n];
-    MovAggregate<int64_t> agg(arena, n);
+    int64_t x[n] = {};
+
+    MovAvgStd<int64_t> comp(arena, n);
+    CHECK(comp.is_valid());
+
     for (size_t i = 0; i < n; i++) {
         x[i] = int64_t(i * n);
-        agg.add(x[i]);
+        comp.add(x[i]);
         double target_avg = 0;
         for (size_t j = 0; j <= i; ++j) {
             target_avg += double(x[j]);
@@ -38,39 +41,42 @@ TEST(mov_aggregate, single_pass) {
         }
         target_var = target_var / double(i + 1);
         double target_std = sqrt(target_var);
-        LONGS_EQUAL((int64_t)round(target_avg), agg.mov_avg());
-        LONGS_EQUAL((int64_t)round(target_var), agg.mov_var());
-        LONGS_EQUAL((int64_t)round(target_std), agg.mov_std());
+        LONGS_EQUAL((int64_t)round(target_avg), comp.mov_avg());
+        LONGS_EQUAL((int64_t)round(target_var), comp.mov_var());
+        LONGS_EQUAL((int64_t)round(target_std), comp.mov_std());
     }
 }
 
-TEST(mov_aggregate, one_n_half_pass) {
+TEST(mov_avg_std, one_n_half_pass) {
     const size_t n = 10;
-    MovAggregate<int64_t> agg(arena, n);
+
+    MovAvgStd<int64_t> comp(arena, n);
+    CHECK(comp.is_valid());
+
     for (size_t i = 0; i < (n * 10 + n / 2); i++) {
         const int64_t x = (int64_t)pow(-1., (double)i);
-        agg.add(x);
+        comp.add(x);
     }
 
-    LONGS_EQUAL(0, agg.mov_avg());
-    LONGS_EQUAL(1, agg.mov_var());
+    LONGS_EQUAL(0, comp.mov_avg());
+    LONGS_EQUAL(1, comp.mov_var());
 
     double target_avg = double(n - 1) * n / 2;
     double target_var = 0;
     for (size_t i = 0; i < n; i++) {
         const int64_t x = int64_t(i * n);
-        agg.add(x);
+        comp.add(x);
         target_var += (x - target_avg) * (x - target_avg);
     }
     target_var /= double(n);
     double target_std = sqrt(target_var);
 
-    LONGS_EQUAL((int64_t)round(target_avg), agg.mov_avg());
-    LONGS_EQUAL((int64_t)round(target_var), agg.mov_var());
-    LONGS_EQUAL((int64_t)round(target_std), agg.mov_std());
+    LONGS_EQUAL((int64_t)round(target_avg), comp.mov_avg());
+    LONGS_EQUAL((int64_t)round(target_var), comp.mov_var());
+    LONGS_EQUAL((int64_t)round(target_std), comp.mov_std());
 }
 
-TEST(mov_aggregate, stress_test) {
+TEST(mov_avg_std, stress_test) {
     enum { NumIterations = 10, NumElems = 1000, MinWindow = 1, MaxWindow = 100 };
 
     const int64_t ranges[][2] = {
@@ -83,8 +89,8 @@ TEST(mov_aggregate, stress_test) {
         for (size_t i = 0; i < NumIterations; i++) {
             const size_t win_sz = core::fast_random_range(MinWindow, MaxWindow);
 
-            MovAggregate<int64_t> agg(arena, win_sz);
-            CHECK(agg.is_valid());
+            MovAvgStd<int64_t> comp(arena, win_sz);
+            CHECK(comp.is_valid());
 
             int64_t elems[NumElems] = {};
 
@@ -92,7 +98,7 @@ TEST(mov_aggregate, stress_test) {
                 elems[n] = ranges[r][0]
                     + (int64_t)core::fast_random_range(
                                0, (uint64_t)(ranges[r][1] - ranges[r][0]));
-                agg.add(elems[n]);
+                comp.add(elems[n]);
 
                 const size_t n_elems = n + 1;
 
@@ -109,9 +115,9 @@ TEST(mov_aggregate, stress_test) {
                 }
                 double target_std = sqrt(target_var);
 
-                DOUBLES_EQUAL(target_avg, agg.mov_avg(), 1);
-                DOUBLES_EQUAL(target_var, agg.mov_var(), 100);
-                DOUBLES_EQUAL(target_std, agg.mov_std(), 100);
+                DOUBLES_EQUAL(target_avg, comp.mov_avg(), 1);
+                DOUBLES_EQUAL(target_var, comp.mov_var(), 100);
+                DOUBLES_EQUAL(target_std, comp.mov_std(), 100);
             }
         }
     }

--- a/src/tests/roc_stat/test_mov_histogram.cpp
+++ b/src/tests/roc_stat/test_mov_histogram.cpp
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <CppUTest/TestHarness.h>
+#include "test_harness.h"
 
 #include "roc_core/heap_arena.h"
 #include "roc_stat/mov_histogram.h"

--- a/src/tests/roc_stat/test_mov_min_max.cpp
+++ b/src/tests/roc_stat/test_mov_min_max.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2024 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "test_harness.h"
+
+#include "roc_core/fast_random.h"
+#include "roc_core/heap_arena.h"
+#include "roc_core/macro_helpers.h"
+#include "roc_stat/mov_min_max.h"
+
+namespace roc {
+namespace stat {
+
+TEST_GROUP(mov_min_max) {
+    core::HeapArena arena;
+};
+
+TEST(mov_min_max, single_pass) {
+    const size_t n = 10;
+    int64_t x[n] = {};
+
+    MovMinMax<int64_t> comp(arena, n);
+    CHECK(comp.is_valid());
+
+    for (size_t i = 0; i < n; i++) {
+        x[i] = int64_t((i + 1) * n);
+        comp.add(x[i]);
+        const int64_t target_min = x[0];
+        const int64_t target_max = x[i];
+        LONGS_EQUAL(target_min, comp.mov_min());
+        LONGS_EQUAL(target_max, comp.mov_max());
+    }
+}
+
+TEST(mov_min_max, two_passes) {
+    const size_t n = 10;
+    int64_t x[n] = {};
+
+    MovMinMax<int64_t> comp(arena, n);
+    CHECK(comp.is_valid());
+
+    for (size_t i = 0; i < n; i++) {
+        x[i] = int64_t((i + 1) * n);
+        comp.add(x[i]);
+        const int64_t target_min = x[0];
+        const int64_t target_max = x[i];
+        LONGS_EQUAL(target_min, comp.mov_min());
+        LONGS_EQUAL(target_max, comp.mov_max());
+    }
+
+    for (size_t i = 0; i < n - 1; i++) {
+        int64_t x2 = int64_t((n + i + 1) * n);
+        comp.add(x2);
+        const int64_t target_min = x[i + 1];
+        const int64_t target_max = x2;
+        LONGS_EQUAL(target_min, comp.mov_min());
+        LONGS_EQUAL(target_max, comp.mov_max());
+    }
+}
+
+TEST(mov_min_max, one_n_half_pass) {
+    const size_t n = 10;
+
+    MovMinMax<int64_t> comp(arena, n);
+    CHECK(comp.is_valid());
+
+    const size_t last_i = (n * 10 + n / 2);
+    for (size_t i = 0; i < last_i; i++) {
+        const int64_t x = int64_t(i * n);
+        comp.add(x);
+    }
+
+    const int64_t target_min = (last_i - n) * n;
+    const int64_t target_max = (last_i - 1) * n;
+    LONGS_EQUAL(target_min, comp.mov_min());
+    LONGS_EQUAL(target_max, comp.mov_max());
+}
+
+TEST(mov_min_max, stress_test) {
+    enum { NumIterations = 10, NumElems = 1000, MinWindow = 1, MaxWindow = 100 };
+
+    const int64_t ranges[][2] = {
+        { 100000000, 200000000 },
+        { -200000000, -100000000 },
+        { -100000000, 100000000 },
+    };
+
+    for (size_t r = 0; r < ROC_ARRAY_SIZE(ranges); r++) {
+        for (size_t i = 0; i < NumIterations; i++) {
+            const size_t win_sz = core::fast_random_range(MinWindow, MaxWindow);
+
+            MovMinMax<int64_t> comp(arena, win_sz);
+            CHECK(comp.is_valid());
+
+            int64_t elems[NumElems] = {};
+
+            for (size_t n = 0; n < NumElems; n++) {
+                elems[n] = ranges[r][0]
+                    + (int64_t)core::fast_random_range(
+                               0, (uint64_t)(ranges[r][1] - ranges[r][0]));
+                comp.add(elems[n]);
+
+                const size_t n_elems = n + 1;
+
+                const size_t cur_win_sz = std::min(win_sz, n_elems);
+                const int64_t* cur_win = elems + n_elems - cur_win_sz;
+
+                int64_t target_min = cur_win[0];
+                for (size_t n = 1; n < cur_win_sz; ++n) {
+                    target_min = std::min(target_min, cur_win[n]);
+                }
+                int64_t target_max = cur_win[0];
+                for (size_t n = 1; n < cur_win_sz; ++n) {
+                    target_max = std::max(target_max, cur_win[n]);
+                }
+
+                LONGS_EQUAL(target_min, comp.mov_min());
+                LONGS_EQUAL(target_max, comp.mov_max());
+            }
+        }
+    }
+}
+
+} // namespace stat
+} // namespace roc

--- a/src/tests/roc_stat/test_mov_quantile.cpp
+++ b/src/tests/roc_stat/test_mov_quantile.cpp
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <CppUTest/TestHarness.h>
+#include "test_harness.h"
 
 #include "roc_core/fast_random.h"
 #include "roc_core/heap_arena.h"


### PR DESCRIPTION
Changes:

- chore: Split MovAggregate into MovAvgStd and MovMinMax
- bugfix: Add tests for MovMinMax and fix bug

See commit messages for details.