### PR TITLE
683: libatomic1 dep: use only when needed + update docs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 # https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 #
 ---
-BasedOnStyle: WebKit # http://www.webkit.org/coding/coding-style.html
+BasedOnStyle: WebKit # https://www.webkit.org/code-style-guidelines/
 
 Standard: Cpp03
 

--- a/SConstruct
+++ b/SConstruct
@@ -671,7 +671,7 @@ if meta.platform == 'darwin':
     conf.FindTool('INSTALL_NAME_TOOL', [''], [('install_name_tool', None)], required=False)
 
 if meta.compiler == 'gcc' or meta.compiler == 'clang':
-    if conf.CheckLib('atomic'):
+    if not GetOption('disable_openssl') and conf.CheckLib('atomic'):
         env.AddManualDependency(libs=['atomic']) # explicitly needed by libcrypto (openssl)
 
 meta.c11_support = False

--- a/docs/sphinx/building/dependencies.rst
+++ b/docs/sphinx/building/dependencies.rst
@@ -124,6 +124,10 @@ Runtime dependencies
 
    SpeexDSP (libspeexdsp) below 1.2rc3 was part of Speex (libspeex) package.
 
+.. note::
+
+   For OpenSSL, you may need to install ``libatomic1`` library package on some systems.
+
 Development dependencies
 ========================
 

--- a/docs/sphinx/building/user_cookbook.rst
+++ b/docs/sphinx/building/user_cookbook.rst
@@ -238,7 +238,7 @@ Raspberry Pi (64-bit)
     $ scp ./bin/aarch64-linux-gnu/libroc.so.*.* <address>:/usr/lib
 
     # install Roc dependencies
-    $ ssh <address> apt-get install libasound2 libpulse0 libltdl7
+    $ ssh <address> apt-get install libasound2 libpulse0 libltdl7 libatomic1
 
 Raspberry Pi 2 and later (32-bit)
 ---------------------------------
@@ -266,7 +266,7 @@ Raspberry Pi 2 and later (32-bit)
     $ scp ./bin/arm-linux-gnueabihf/libroc.so.*.* <address>:/usr/lib
 
     # install Roc dependencies
-    $ ssh <address> apt-get install libasound2 libpulse0 libltdl7
+    $ ssh <address> apt-get install libasound2 libpulse0 libltdl7 libatomic1
 
 Raspberry Pi 1 and Zero (32-bit)
 --------------------------------
@@ -293,7 +293,7 @@ Raspberry Pi 1 and Zero (32-bit)
     $ scp ./bin/arm-bcm2708hardfp-linux-gnueabi/libroc.so.*.* <address>:/usr/lib
 
     # install Roc dependencies
-    $ ssh <address> apt-get install libasound2 libpulse0 libltdl7
+    $ ssh <address> apt-get install libasound2 libpulse0 libltdl7 libatomic1
 
 OpenWrt (MIPS32 24Kc, Artheos, musl)
 ------------------------------------

--- a/docs/sphinx/portability/cross_compiling.rst
+++ b/docs/sphinx/portability/cross_compiling.rst
@@ -354,19 +354,25 @@ You can either copy their binaries from ``3rdparty/<toolchain>/rpath`` directory
 
 Here are examples for Raspbian:
 
-If ALSA support is enabled, install libasound:
+If ALSA support is enabled, install ``libasound``:
 
 .. code::
 
    $ apt-get install libasound2
 
-If PulseAudio support is enabled, install libltdl and libpulse:
+If PulseAudio support is enabled, install ``libltdl`` and ``libpulse``:
 
 .. code::
 
    $ apt-get install libltdl7 libpulse0
 
 .. _qemu:
+
+If OpenSSL support is enabled, install ``libatomic1``:
+
+.. code::
+
+   $ apt-get install libatomic1
 
 Running cross-compiled tests in QEMU
 ====================================

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,7 @@
+# Development shell initialization for NixOS.
+#
+# Details: https://roc-streaming.org/toolkit/docs/building/dependencies.html
+
 { pkgs ? import <nixpkgs> {} }:
 
 pkgs.clangStdenv.mkDerivation {

--- a/src/internal_modules/roc_core/secure_random.h
+++ b/src/internal_modules/roc_core/secure_random.h
@@ -15,9 +15,6 @@
 #include "roc_core/attributes.h"
 #include "roc_core/stddefs.h"
 
-//! @warning On some platforms CSPRNG is not available. In this case a non-secure version
-//! may be used instead (e.g. @p fast_random*()).
-
 namespace roc {
 namespace core {
 
@@ -25,6 +22,9 @@ namespace core {
 //! Thread-safe. Uniformly distributed.
 //!
 //! @returns @p true in case of success, @p false in case of failure.
+//!
+//! @warning On some platforms CSPRNG is not available. In this case a non-secure version
+//! may be used instead (e.g. @p fast_random*()).
 ROC_NODISCARD
 bool secure_random(void* buf, size_t bufsz);
 
@@ -32,6 +32,9 @@ bool secure_random(void* buf, size_t bufsz);
 //! Thread-safe. Uniformly distributed.
 //!
 //! @returns @p true in case of success, @p false in case of failure.
+//!
+//! @warning On some platforms CSPRNG is not available. In this case a non-secure version
+//! may be used instead (e.g. @p fast_random*()).
 ROC_NODISCARD
 bool secure_random_range_32(uint32_t from, uint32_t to, uint32_t& dest);
 
@@ -39,6 +42,9 @@ bool secure_random_range_32(uint32_t from, uint32_t to, uint32_t& dest);
 //! Thread-safe. Uniformly distributed.
 //!
 //! @returns @p true in case of success, @p false in case of failure.
+//!
+//! @warning On some platforms CSPRNG is not available. In this case a non-secure version
+//! may be used instead (e.g. @p fast_random*()).
 ROC_NODISCARD
 bool secure_random_range_64(uint64_t from, uint64_t to, uint64_t& dest);
 


### PR DESCRIPTION
related to #683

behaviour changes:
- only link with `libatomic1` with enabled OpenSSL

documentation changes regarding `libatomic1` dependency