### PR TITLE
Add StateTracker::wait_state() and converted linux semaphore timed wait into monotonic clock domain 

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -955,6 +955,20 @@ if meta.compiler in ['gcc', 'clang']:
     if meta.platform in ['linux', 'darwin']:
         env.AddManualDependency(libs=['pthread'])
 
+#Check for existence of function sem_clockwait 
+    temp_conf = Configure(env)
+    header = """
+#ifdef __cplusplus
+extern "C"
+#endif
+char sem_timedwait(void);
+"""
+
+    if temp_conf.CheckFunc('sem_clockwait', header):
+        env.Append(CPPDEFINES=['ROC_HAVE_SEM_CLOCKWAIT'])
+
+
+
     if meta.platform in ['linux', 'android'] or meta.gnu_toolchain:
         if not GetOption('disable_soversion'):
             subenvs.public_libs['SHLIBSUFFIX'] = '{}.{}'.format(

--- a/src/internal_modules/roc_core/target_posix_ext/roc_core/semaphore.cpp
+++ b/src/internal_modules/roc_core/target_posix_ext/roc_core/semaphore.cpp
@@ -9,8 +9,8 @@
 #include "roc_core/semaphore.h"
 #include "roc_core/cpu_instructions.h"
 #include "roc_core/errno_to_str.h"
-#include "roc_core/panic.h"
 #include "roc_core/log.h"
+#include "roc_core/panic.h"
 
 #include <errno.h>
 #include <time.h>
@@ -41,30 +41,31 @@ bool Semaphore::timed_wait(nanoseconds_t deadline) {
 
     nanoseconds_t converted_deadline = deadline;
 
-    // convert deadline's domain into CLOCK_REALTIME if sem_clockwait is not available
-    #ifndef ROC_HAVE_SEM_CLOCKWAIT
-    converted_deadline += (core::timestamp(core::ClockUnix)-core::timestamp(core::ClockMonotonic));
-    #endif
+// convert deadline's domain into CLOCK_REALTIME if sem_clockwait is not available
+#ifndef ROC_HAVE_SEM_CLOCKWAIT
+    converted_deadline +=
+        (core::timestamp(core::ClockUnix) - core::timestamp(core::ClockMonotonic));
+#endif
 
-    roc_log(roc::LogDebug,"origin time is %" PRId64"\n", deadline);
-    roc_log(roc::LogDebug,"time is %" PRId64"\n", converted_deadline);
-    roc_log(roc::LogDebug,"now time is %" PRId64"\n", core::timestamp(core::ClockMonotonic));
+    roc_log(roc::LogDebug, "origin time is %" PRId64 "\n", deadline);
+    roc_log(roc::LogDebug, "time is %" PRId64 "\n", converted_deadline);
+    roc_log(roc::LogDebug, "now time is %" PRId64 "\n",
+            core::timestamp(core::ClockMonotonic));
 
     timespec ts;
     ts.tv_sec = long(converted_deadline / Second);
     ts.tv_nsec = long(converted_deadline % Second);
-    
-    for (;;) {
 
-        #ifdef ROC_HAVE_SEM_CLOCKWAIT
-        if (sem_clockwait(&sem_, CLOCK_MONOTONIC , &ts) == 0) {
+    for (;;) {
+#ifdef ROC_HAVE_SEM_CLOCKWAIT
+        if (sem_clockwait(&sem_, CLOCK_MONOTONIC, &ts) == 0) {
             return true;
         }
-        #else
+#else
         if (sem_timedwait(&sem_, &ts) == 0) {
-          return true;
+            return true;
         }
-        #endif 
+#endif
 
         if (errno == ETIMEDOUT) {
             return false;

--- a/src/internal_modules/roc_pipeline/state_tracker.cpp
+++ b/src/internal_modules/roc_pipeline/state_tracker.cpp
@@ -7,15 +7,73 @@
  */
 
 #include "roc_pipeline/state_tracker.h"
+#include "roc_core/log.h"
 #include "roc_core/panic.h"
 
 namespace roc {
 namespace pipeline {
 
 StateTracker::StateTracker()
-    : halt_state_(-1)
+    : sem_(0)
+    , halt_state_(-1)
     , active_sessions_(0)
-    , pending_packets_(0) {
+    , pending_packets_(0)
+    , sem_is_occupied_(0)
+    , waiting_mask_(0)
+    , mutex_()
+    , waiting_con_(mutex_) {
+}
+
+// StateTracker::~StateTracker() {
+//     mutex_.unlock();
+// }
+
+// This method should block until the state becomes any of the states specified by the
+// mask, or deadline expires. E.g. if mask is ACTIVE | PAUSED, it should block until state
+// becomes either ACTIVE or PAUSED. (Currently only two states are used, but later more
+// states will be needed). Deadline should be an absolute timestamp.
+
+// Questions:
+// - When should the function return true vs false
+bool StateTracker::wait_state(unsigned int state_mask, core::nanoseconds_t deadline) {
+    waiting_mask_ = state_mask;
+    for (;;) {
+        // If no state is specified in state_mask, return immediately
+        if (state_mask == 0) {
+            return true;
+        }
+
+        if (static_cast<unsigned>(get_state()) & state_mask) {
+            waiting_mask_ = 0;
+            return true;
+        }
+
+        if (deadline >= 0 && deadline <= core::timestamp(core::ClockMonotonic)) {
+            waiting_mask_ = 0;
+            return false;
+        }
+
+        if (sem_is_occupied_.compare_exchange(0, 1)) {
+            if (deadline >= 0) {
+                (void)sem_.timed_wait(deadline);
+
+            } else {
+                sem_.wait();
+            }
+
+            sem_is_occupied_ = 0;
+            waiting_con_.broadcast();
+
+        } else {
+            core::Mutex::Lock lock(mutex_);
+
+            if (deadline >= 0) {
+                (void)waiting_con_.timed_wait(deadline);
+            } else {
+                waiting_con_.wait();
+            }
+        }
+    }
 }
 
 sndio::DeviceState StateTracker::get_state() const {
@@ -65,22 +123,50 @@ size_t StateTracker::num_sessions() const {
 }
 
 void StateTracker::register_session() {
-    active_sessions_++;
-}
-
-void StateTracker::unregister_session() {
-    if (--active_sessions_ < 0) {
-        roc_panic("state tracker: unpaired register/unregister session");
+    if (active_sessions_++ == 0) {
+        signal_state_change();
     }
 }
 
+void StateTracker::unregister_session() {
+    int prev_sessions = active_sessions_--;
+    if (prev_sessions == 0) {
+        roc_panic("state tracker: unpaired register/unregister session");
+    } else if (prev_sessions == 1 && pending_packets_ == 0) {
+        signal_state_change();
+    }
+
+    // if (--active_sessions_ < 0) {
+    //     roc_panic("state tracker: unpaired register/unregister session");
+    // }
+}
+
 void StateTracker::register_packet() {
-    pending_packets_++;
+    if (pending_packets_++ == 0 && active_sessions_ == 0) {
+        signal_state_change();
+    }
 }
 
 void StateTracker::unregister_packet() {
-    if (--pending_packets_ < 0) {
+    int prev_packets = pending_packets_--;
+    if (prev_packets == 0) {
         roc_panic("state tracker: unpaired register/unregister packet");
+    } else if (prev_packets == 1 && active_sessions_ == 0) {
+        signal_state_change();
+    }
+
+    // if (--pending_packets_ < 0) {
+    //     roc_panic("state tracker: unpaired register/unregister packet");
+    // }
+}
+
+void StateTracker::signal_state_change() {
+    // if (waiting_mask_ != 0 && (static_cast<unsigned>(get_state()) & waiting_mask_)) {
+    //     sem_.post();
+    // }
+    if (sem_is_occupied_) {
+        roc_log(LogDebug, "signaling");
+        sem_.post();
     }
 }
 

--- a/src/internal_modules/roc_pipeline/state_tracker.h
+++ b/src/internal_modules/roc_pipeline/state_tracker.h
@@ -19,7 +19,7 @@
 #include "roc_core/semaphore.h"
 #include "roc_core/stddefs.h"
 #include "roc_core/time.h"
-#include "roc_sndio/device_state.h"
+#include "roc_sndio/device_defs.h"
 
 namespace roc {
 namespace pipeline {

--- a/src/internal_modules/roc_pipeline/state_tracker.h
+++ b/src/internal_modules/roc_pipeline/state_tracker.h
@@ -13,9 +13,13 @@
 #define ROC_PIPELINE_STATE_TRACKER_H_
 
 #include "roc_core/atomic.h"
+#include "roc_core/cond.h"
+#include "roc_core/mutex.h"
 #include "roc_core/noncopyable.h"
+#include "roc_core/semaphore.h"
 #include "roc_core/stddefs.h"
-#include "roc_sndio/device_defs.h"
+#include "roc_core/time.h"
+#include "roc_sndio/device_state.h"
 
 namespace roc {
 namespace pipeline {
@@ -31,6 +35,9 @@ class StateTracker : public core::NonCopyable<> {
 public:
     //! Initialize all counters to zero.
     StateTracker();
+
+    //! Block until state becomes any of the ones specified by state_mask.
+    bool wait_state(unsigned state_mask, core::nanoseconds_t deadline);
 
     //! Compute current state.
     sndio::DeviceState get_state() const;
@@ -63,9 +70,16 @@ public:
     void unregister_packet();
 
 private:
+    core::Semaphore sem_;
     core::Atomic<int> halt_state_;
     core::Atomic<int> active_sessions_;
     core::Atomic<int> pending_packets_;
+    core::Atomic<int> sem_is_occupied_;
+    core::Atomic<unsigned> waiting_mask_;
+    core::Mutex mutex_;
+    core::Cond waiting_con_;
+
+    void signal_state_change();
 };
 
 } // namespace pipeline

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "test_harness.h"
+
+#include "roc_address/protocol.h"
+#include "roc_audio/mixer.h"
+#include "roc_audio/sample.h"
+#include "roc_core/atomic.h"
+#include "roc_core/heap_arena.h"
+#include "roc_core/noop_arena.h"
+#include "roc_core/thread.h"
+#include "roc_core/time.h"
+#include "roc_pipeline/config.h"
+#include "roc_pipeline/receiver_endpoint.h"
+#include "roc_pipeline/receiver_session_group.h"
+#include "roc_core/semaphore.h"
+
+namespace roc {
+namespace pipeline {
+
+namespace {
+
+enum { PacketSz = 512 };
+
+core::HeapArena arena;
+
+packet::PacketFactory packet_factory(arena, PacketSz);
+audio::FrameFactory frame_factory(arena, PacketSz * sizeof(audio::sample_t));
+
+audio::ProcessorMap processor_map(arena);
+rtp::EncodingMap encoding_map(arena);
+
+class TestThread : public core::Thread {
+public:
+    TestThread(StateTracker& st, unsigned int state_mask, core::nanoseconds_t deadline)
+        : t_(st)
+        , r_(0)
+        , state_mask_(state_mask)
+        , deadline_(deadline) {
+    }
+
+    bool running() const {
+        return r_;
+    }
+
+    void wait_running() {
+        while (!r_) {
+            core::sleep_for(core::ClockMonotonic, core::Microsecond);
+        }
+    }
+
+private:
+    virtual void run() {
+        r_ = true;
+        t_.wait_state(state_mask_, deadline_);
+        r_ = false;
+    }
+
+    StateTracker& t_;
+    core::Atomic<int> r_;
+    unsigned int state_mask_;
+    core::nanoseconds_t deadline_;
+};
+
+} // namespace
+
+TEST_GROUP(state_tracker) {};
+
+TEST(state_tracker, simple_timeout) {
+    StateTracker state_tracker;
+    TestThread thr(state_tracker, sndio::DeviceState_Active,
+                   core::timestamp(core::ClockMonotonic) + core::Millisecond * 500);
+
+    CHECK(thr.start());
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 1000);
+    CHECK(!(thr.running()));
+    thr.join();
+}
+
+TEST(state_tracker, multiple_timeout) {
+    StateTracker state_tracker;
+    TestThread** threads_ptr = new TestThread*[10];
+    for (int i = 0; i < 10; i++) {
+        threads_ptr[i] =
+            new TestThread(state_tracker, sndio::DeviceState_Active,
+                           core::timestamp(core::ClockMonotonic) + core::Millisecond * 1000);
+    }
+
+    for (int i = 0; i < 10; i++) {
+        CHECK(threads_ptr[i]->start());
+    }
+
+    roc_log(LogDebug, "started running");
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 2000);
+
+    for (int i = 0; i < 10; i++) {
+        CHECK(!threads_ptr[i]->running());
+    }
+
+    roc_log(LogDebug, "started joining");
+
+    for (int i = 0; i < 10; i++) {
+        threads_ptr[i]->join();
+    }
+
+    roc_log(LogDebug, "finished joining");
+}
+
+TEST(state_tracker, multiple_switch) {
+    StateTracker state_tracker;
+    TestThread** threads_ptr = new TestThread*[10];
+    for (int i = 0; i < 10; i++) {
+        threads_ptr[i] = new TestThread(state_tracker, sndio::DeviceState_Active, -1);
+    }
+
+    for (int i = 0; i < 10; i++) {
+        CHECK(threads_ptr[i]->start());
+    }
+
+    roc_log(LogDebug, "started running");
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
+
+    for (int i = 0; i < 10; i++) {
+        CHECK(threads_ptr[i]->running());
+    }
+
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
+    state_tracker.register_packet();
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
+
+    for (int i = 0; i < 10; i++) {
+        CHECK(!(threads_ptr[i]->running()));
+    }
+
+    roc_log(LogDebug, "started joining");
+    for (int i = 0; i < 10; i++) {
+        threads_ptr[i]->join();
+    }
+    roc_log(LogDebug, "finished joining");
+}
+
+TEST(state_tracker, semaphore_test) {
+    core::Semaphore sem(0);
+    if (sem.timed_wait(1 * core::Second + core::timestamp(core::ClockMonotonic)))
+        roc_log(LogDebug, "true");
+    else
+        roc_log(LogDebug, "false");
+}
+} // namespace pipeline
+} // namespace roc

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -14,12 +14,12 @@
 #include "roc_core/atomic.h"
 #include "roc_core/heap_arena.h"
 #include "roc_core/noop_arena.h"
+#include "roc_core/semaphore.h"
 #include "roc_core/thread.h"
 #include "roc_core/time.h"
 #include "roc_pipeline/config.h"
 #include "roc_pipeline/receiver_endpoint.h"
 #include "roc_pipeline/receiver_session_group.h"
-#include "roc_core/semaphore.h"
 
 namespace roc {
 namespace pipeline {
@@ -88,31 +88,30 @@ TEST(state_tracker, multiple_timeout) {
     StateTracker state_tracker;
     TestThread** threads_ptr = new TestThread*[10];
 
-    //set threads that last for 1 second
+    // set threads that last for 1 second
     for (int i = 0; i < 10; i++) {
-        threads_ptr[i] =
-            new TestThread(state_tracker, sndio::DeviceState_Active,
-                           core::timestamp(core::ClockMonotonic) + core::Millisecond * 1000);
+        threads_ptr[i] = new TestThread(state_tracker, sndio::DeviceState_Active,
+                                        core::timestamp(core::ClockMonotonic)
+                                            + core::Millisecond * 1000);
     }
 
-    //wait for start, then check if threads are running
+    // wait for start, then check if threads are running
     for (int i = 0; i < 10; i++) {
         CHECK(threads_ptr[i]->start());
         // CHECK(threads_ptr[i]->running());
         // roc_log(LogDebug, "check running %d\n", i);
-
     }
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 10);
     for (int i = 0; i < 10; i++) {
-      //roc_log(LogDebug, "check running %d\n", i);
-      CHECK(threads_ptr[i]->running());
+        // roc_log(LogDebug, "check running %d\n", i);
+        CHECK(threads_ptr[i]->running());
     }
 
-    //sleep for 2 seconds, making the threads timeout
+    // sleep for 2 seconds, making the threads timeout
     roc_log(LogDebug, "started running");
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 2000);
 
-    //check if threads are stopped
+    // check if threads are stopped
     for (int i = 0; i < 10; i++) {
         CHECK(!threads_ptr[i]->running());
     }
@@ -130,7 +129,7 @@ TEST(state_tracker, multiple_switch) {
     StateTracker state_tracker;
     TestThread** threads_ptr = new TestThread*[10];
 
-    //set threads without waiting time
+    // set threads without waiting time
     for (int i = 0; i < 10; i++) {
         threads_ptr[i] = new TestThread(state_tracker, sndio::DeviceState_Active, -1);
     }
@@ -141,20 +140,20 @@ TEST(state_tracker, multiple_switch) {
 
     roc_log(LogDebug, "started running");
 
-    //wait for threads starting
+    // wait for threads starting
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
 
-    //check if the threads have started
+    // check if the threads have started
     for (int i = 0; i < 10; i++) {
         CHECK(threads_ptr[i]->running());
     }
 
-    //register a packet
+    // register a packet
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
     state_tracker.register_packet();
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
 
-    //check if the threads have been stopped
+    // check if the threads have been stopped
     for (int i = 0; i < 10; i++) {
         CHECK(!(threads_ptr[i]->running()));
     }


### PR DESCRIPTION
Implement #749 based on #769.
Fix according to #795 so the above implementation works

1. Make the Waiting Threads waiting using condition variables according to https://github.com/roc-streaming/roc-toolkit/issues/749#issuecomment-2255804185
2. According to https://github.com/roc-streaming/roc-toolkit/pull/797#issuecomment-2615079232, added compile time check in SConstruct for whether sem_clockedwait exist, set the clock of timedwait in POSIX platforms into CLOCK_MONOTONIC domain. Document of checkFunc can be found at https://scons.org/doc/2.3.1/HTML/scons-api/SCons.Conftest-pysrc.html#CheckFunc
3. Added simple test cases of state_tracker's timeout and blocking.
4. Added simple test case of POSIX semaphore's timeout. 