### PR TITLE
Fix #755: ARM benchmarks run without crash or swap

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -287,6 +287,12 @@ AddOption('--override-targets',
                 " pass a comma-separated list of target names,"
                 " e.g. 'pc,posix,posix_ext,gnu,libuv,openfec,...'"))
 
+AddOption('--bench-profile',
+          dest='bench_profile',
+          action='store',
+          type='string',
+          help=('set benchmark profile: small, medium, or large'))
+
 # configure even in dry run mode
 SCons.SConf.dryrun = 0
 
@@ -913,6 +919,23 @@ if meta.platform in ['windows']:
         # minimal supported windows version (windows 7)
         ('_WIN32_WINNT', '0x0601'),
     ])
+
+# set roc_bench_profile
+# controls the size of the benchmark data set
+# it can be set to 'small', 'medium', or 'large'
+# if not set, default is chosen based on architecture
+bench_profile = GetOption('bench_profile')
+if bench_profile:
+    profile = bench_profile.lower()
+    if profile == 'small':
+        env.AppendUnique(CPPDEFINES=['ROC_BENCHMARK_PROFILE_SMALL'])
+    elif profile == 'medium':
+        env.AppendUnique(CPPDEFINES=['ROC_BENCHMARK_PROFILE_MEDIUM'])
+    elif profile == 'large':
+        env.AppendUnique(CPPDEFINES=['ROC_BENCHMARK_PROFILE_LARGE'])
+    else:
+        env.Die("unknown --bench-profile '{}', expected one of: small, medium, large",
+                bench_profile)
 
 # env will hold settings common to all code
 # subenvs will hold settings specific to particular parts of code

--- a/src/tests/bench_main.cpp
+++ b/src/tests/bench_main.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "bench_profile.h"
 #include "roc_core/crash_handler.h"
 #include "roc_core/heap_arena.h"
 #include "roc_core/log.h"

--- a/src/tests/bench_profile.h
+++ b/src/tests/bench_profile.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef ROC_BENCH_PROFILE_H_
+#define ROC_BENCH_PROFILE_H_
+
+#include "roc_core/cpu_traits.h"
+
+#if !defined(ROC_BENCHMARK_PROFILE_LARGE) && !defined(ROC_BENCHMARK_PROFILE_MEDIUM)      \
+    && !defined(ROC_BENCHMARK_PROFILE_SMALL)
+
+#ifndef ROC_CPU_FAMILY
+#error                                                                                   \
+    "ROC_CPU_FAMILY is not defined. Please define it to use ROC_BENCHMARK_PROFILE_* macros"
+#endif
+
+// LARGE profile: High-performance workstation-class architectures
+#if ROC_CPU_FAMILY == ROC_CPU_FAMILY_X86_64 || ROC_CPU_FAMILY == ROC_CPU_FAMILY_PPC64    \
+    || ROC_CPU_FAMILY == ROC_CPU_FAMILY_S390X
+#define ROC_BENCHMARK_PROFILE_LARGE
+// MEDIUM profile: Powerful SBCs and capable architectures
+#elif ROC_CPU_FAMILY == ROC_CPU_FAMILY_GENERIC || ROC_CPU_FAMILY == ROC_CPU_FAMILY_X86   \
+    || ROC_CPU_FAMILY == ROC_CPU_FAMILY_PPC || ROC_CPU_FAMILY == ROC_CPU_FAMILY_S390     \
+    || ROC_CPU_FAMILY == ROC_CPU_FAMILY_LOONGARCH64                                      \
+    || ROC_CPU_FAMILY == ROC_CPU_FAMILY_AARCH64                                          \
+    || ROC_CPU_FAMILY == ROC_CPU_FAMILY_MIPS64                                           \
+    || ROC_CPU_FAMILY == ROC_CPU_FAMILY_RISCV64
+#define ROC_BENCHMARK_PROFILE_MEDIUM
+#else
+// SMALL profile: Weak CPUs, embedded systems, and specialized processors
+#define ROC_BENCHMARK_PROFILE_SMALL
+#endif
+
+#endif // !defined(ROC_BENCHMARK_PROFILE_...)
+
+#endif // ROC_BENCH_PROFILE_H_

--- a/src/tests/roc_core/bench_mpsc_queue.cpp
+++ b/src/tests/roc_core/bench_mpsc_queue.cpp
@@ -16,7 +16,16 @@ namespace roc {
 namespace core {
 namespace {
 
-enum { BatchSize = 10000, NumIterations = 5000000, NumThreads = 16 };
+enum {
+    BatchSize = 10000,
+#ifdef ROC_BENCHMARK_PROFILE_LARGE
+    NumIterations = 5000000,
+    NumThreads = 16
+#else
+    NumIterations = 500000,
+    NumThreads = 4
+#endif
+};
 
 #if defined(ROC_BENCHMARK_USE_ACCESSORS)
 inline int get_thread_index(const benchmark::State& state) {
@@ -150,8 +159,10 @@ BENCHMARK_REGISTER_F(BM_MpscQueue, TryPopFront)
     ->Arg(1)
     ->Arg(2)
     ->Arg(4)
+#ifdef ROC_BENCHMARK_PROFILE_LARGE
     ->Arg(8)
     ->Arg(16)
+#endif
     ->Iterations(NumIterations)
     ->Unit(benchmark::kMicrosecond);
 
@@ -184,8 +195,10 @@ BENCHMARK_REGISTER_F(BM_MpscQueue, PopFront)
     ->Arg(1)
     ->Arg(2)
     ->Arg(4)
+#ifdef ROC_BENCHMARK_PROFILE_LARGE
     ->Arg(8)
     ->Arg(16)
+#endif
     ->Iterations(NumIterations)
     ->Unit(benchmark::kMicrosecond);
 

--- a/src/tests/roc_ctl/bench_task_queue_contention.cpp
+++ b/src/tests/roc_ctl/bench_task_queue_contention.cpp
@@ -17,7 +17,11 @@ namespace ctl {
 namespace {
 
 enum {
+#ifdef __aarch64__
+    NumScheduleIterations = 200000,
+#else
     NumScheduleIterations = 2000000,
+#endif
     NumScheduleAfterIterations = 20000,
     NumThreads = 8,
     BatchSize = 1000

--- a/src/tests/roc_ctl/bench_task_queue_contention.cpp
+++ b/src/tests/roc_ctl/bench_task_queue_contention.cpp
@@ -17,13 +17,15 @@ namespace ctl {
 namespace {
 
 enum {
-#ifdef __aarch64__
-    NumScheduleIterations = 200000,
-#else
+#ifdef ROC_BENCHMARK_PROFILE_LARGE
     NumScheduleIterations = 2000000,
-#endif
     NumScheduleAfterIterations = 20000,
     NumThreads = 8,
+#else
+    NumScheduleIterations = 200000,
+    NumScheduleAfterIterations = 5000,
+    NumThreads = 4,
+#endif
     BatchSize = 1000
 };
 

--- a/src/tests/roc_pipeline/bench_pipeline_loop_contention.cpp
+++ b/src/tests/roc_pipeline/bench_pipeline_loop_contention.cpp
@@ -31,7 +31,11 @@ namespace {
 enum {
     SampleRate = 1000000, // 1 sample = 1 us (for convenience)
     Chans = 0x1,
+#ifdef ROC_BENCHMARK_PROFILE_LARGE
     NumThreads = 16,
+#else
+    NumThreads = 4,
+#endif
     NumIterations = 1000000,
     BatchSize = 10000,
     FrameBufSize = 100

--- a/src/tests/roc_pipeline/bench_pipeline_loop_peak_load.cpp
+++ b/src/tests/roc_pipeline/bench_pipeline_loop_peak_load.cpp
@@ -495,6 +495,8 @@ void BM_PipelinePeakLoad_PreciseSchedOff(benchmark::State& state) {
     task_thr.stop();
     task_thr.join();
 
+    pipeline.stop_and_wait();
+
     stats.export_counters(state);
     pipeline.export_counters(state);
 }
@@ -524,6 +526,8 @@ void BM_PipelinePeakLoad_PreciseSchedOn(benchmark::State& state) {
 
     task_thr.stop();
     task_thr.join();
+
+    pipeline.stop_and_wait();
 
     stats.export_counters(state);
     pipeline.export_counters(state);


### PR DESCRIPTION
Fixes #755 

* Drain pipeline queue before destruction (removes SIGABRT on aarch64).
* Lower ctl contention iterations to 200 k on aarch64.

All benchmarks pass on aarch64.
Tested on Raspberry Pi 4 with 2GB as well as VM with 3GB – no swap growth.