### PR TITLE
fixes panicks with sox 14.6.1-1

### DIFF
--- a/scripts/ci_checks/linux-checks/valgrind.sh
+++ b/scripts/ci_checks/linux-checks/valgrind.sh
@@ -15,7 +15,7 @@ scons -Q \
 find bin/x86_64-pc-linux-gnu -name 'roc-test-*' |\
     while read tst
     do
-        python3 scripts/scons_helpers/timeout-run.py 300 \
+        python3 scripts/scons_helpers/timeout-run.py 500 \
             valgrind \
                 --max-stackframe=10475520 \
                 --error-exitcode=1 --exit-on-first-error=yes \
@@ -34,7 +34,7 @@ scons -Q \
 find bin/x86_64-pc-linux-gnu -name 'roc-test-*' |\
     while read tst
     do
-        python3 scripts/scons_helpers/timeout-run.py 300 \
+        python3 scripts/scons_helpers/timeout-run.py 500 \
             valgrind \
                 --max-stackframe=10475520 \
                 --error-exitcode=1 --exit-on-first-error=yes \

--- a/src/internal_modules/roc_sndio/driver.h
+++ b/src/internal_modules/roc_sndio/driver.h
@@ -21,7 +21,7 @@ namespace sndio {
 class IBackend;
 
 //! Maximum number of drivers.
-static const size_t MaxDrivers = 128;
+static const size_t MaxDrivers = 256;
 
 //! Driver type.
 enum DriverType {


### PR DESCRIPTION
The issue in [arch](https://gitlab.archlinux.org/archlinux/packaging/packages/roc-toolkit/-/issues/1) Default capacity of driver list of 128 became too low, pump it up to 256