### PR TITLE
fix: correct install paths for shared library and pkg-config file

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -123,7 +123,7 @@ if not GetOption('disable_shared') or GetOption('enable_static') or GetOption('e
         public_api_targets += [install_target]
         public_api_targets += symlinks
 
-        env.AddDistFile(env['ROC_SYSTEM_LIBDIR'], install_target)
+        env.AddDistFile(env['ROC_SYSTEM_LIBDIR'], libroc_shared[0])
 
         if env.NeedsFixupSharedLibrary():
             env.AddDistAction(env.FixupSharedLibrary(
@@ -166,6 +166,8 @@ if not GetOption('disable_shared') or GetOption('enable_static') or GetOption('e
         env.Alias('public_api', public_api_targets, env.Action(''))
         env.AlwaysBuild('public_api')
 
+        env.Depends('install', public_api_targets)
+
         env.AddDistFile(env['ROC_SYSTEM_INCDIR'], '#src/public_api/include/roc')
 
         pc_file = env.GeneratePkgConfig(
@@ -177,6 +179,8 @@ if not GetOption('disable_shared') or GetOption('enable_static') or GetOption('e
             desc='Real-time audio streaming over the network.',
             url='https://roc-streaming.org',
             version=env['ROC_VERSION'])
+
+        public_api_targets += [pc_file]
 
         env.AddDistFile(env['ROC_SYSTEM_PCDIR'], pc_file)
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -123,7 +123,7 @@ if not GetOption('disable_shared') or GetOption('enable_static') or GetOption('e
         public_api_targets += [install_target]
         public_api_targets += symlinks
 
-        env.AddDistFile(env['ROC_SYSTEM_LIBDIR'], install_target)
+        env.AddDistFile(env['ROC_SYSTEM_LIBDIR'], libroc_shared[0])
 
         if env.NeedsFixupSharedLibrary():
             env.AddDistAction(env.FixupSharedLibrary(
@@ -177,6 +177,8 @@ if not GetOption('disable_shared') or GetOption('enable_static') or GetOption('e
             desc='Real-time audio streaming over the network.',
             url='https://roc-streaming.org',
             version=env['ROC_VERSION'])
+
+        public_api_targets += [pc_file]
 
         env.AddDistFile(env['ROC_SYSTEM_PCDIR'], pc_file)
 
@@ -345,4 +347,11 @@ if env.get('ROC_CLANGDB', None):
     compile_commands = env['ROC_CLANGDB']
 
     env.Artifact(compile_commands, all_targets)
-    env.Install('#', compile_commands)
+    target = env.Install('#', compile_commands)
+
+    all_targets += [target]
+
+#
+# ensure 'install' goes last
+#
+env.Depends('install', all_targets)


### PR DESCRIPTION
When installing to system paths, the build was failing with "No such file or directory" errors because AddDistFile was trying to copy from intermediate install locations that didn't exist.

```
# sudo scons -Q --enable-werror --build-3rdparty=all --disable-pulseaudio --disable-openssl --enable-tests install
  INSTALL /usr/share/man/man1/roc-copy.1 
  INSTALL /usr/share/man/man1/roc-recv.1 
  INSTALL /usr/share/man/man1/roc-send.1 
  INSTALL /usr/lib/x86_64-linux-gnu/libroc.so.0.4 
scons: *** [install] bin/x86_64-pc-linux-gnu/libroc.so.0.4: No such file or directory
```