### PR TITLE
Implement StateTracker::wait_state() with lock-free wakeup and Implement semaphore using condvar and mutex

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -782,10 +782,15 @@ else:
             'target_posix_pc',
         ])
 
-    if meta.platform in ['linux', 'unix', 'android']:
-        env.Append(ROC_TARGETS=[
-            'target_posix_ext',
-        ])
+    if meta.platform in ['linux', 'android', 'unix']:
+        if 'ROC_HAVE_SEM_CLOCKWAIT' in env['CPPDEFINES']:
+            env.Append(ROC_TARGETS=[
+                'target_posix_sem',
+            ])
+        else:
+            env.Append(ROC_TARGETS=[
+                'target_nosem',
+            ])
 
     if meta.platform in ['linux', 'unix', 'macos', 'windows', 'android']:
         env.Append(ROC_TARGETS=[

--- a/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
+++ b/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
@@ -28,7 +28,8 @@ Semaphore::Semaphore(unsigned counter)
         roc_panic("semaphore: pthread_condattr_init(): %s", errno_to_str(err).c_str());
     }
     if (int err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC)) {
-        roc_panic("semaphore: pthread_condattr_setclock(): %s", errno_to_str(err).c_str());
+        roc_panic("semaphore: pthread_condattr_setclock(): %s",
+                  errno_to_str(err).c_str());
     }
     if (int err = pthread_cond_init(&cond_, &attr)) {
         roc_panic("semaphore: pthread_cond_init(): %s", errno_to_str(err).c_str());

--- a/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
+++ b/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
@@ -43,35 +43,25 @@ bool Semaphore::timed_wait(nanoseconds_t deadline) {
         roc_panic("semaphore: unexpected negative deadline");
     }
 
-    roc_log(roc::LogDebug, "origin time is %" PRId64 "\n", deadline);
-    roc_log(roc::LogDebug, "time is %" PRId64 "\n", deadline);
-    roc_log(roc::LogDebug, "now time is %" PRId64 "\n",
-            core::timestamp(core::ClockMonotonic));
-
     struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    deadline += (nanoseconds_t)ts.tv_sec * Second + (nanoseconds_t)ts.tv_nsec;
     ts.tv_sec = time_t(deadline / Second);
     ts.tv_nsec = long(deadline % Second);
 
     int err = 0;
     mutex_.lock();
     while (err == 0 && counter_ == 0) {
-        err = pthread_cond_clockwait(&cond_, &mutex_.mutex_, CLOCK_MONOTONIC, &ts);
-        printf("finish waiting without sem");
-        // roc_log(roc::LogDebug, "finish waiting without sem");
-
-        if (err != 0 && err != ETIMEDOUT) {
-            roc_panic("semaphore: pthread_cond_timedwait(): %s",
-                      errno_to_str(err).c_str());
-        }
+        err = pthread_cond_timedwait(&cond_, &mutex_.mutex_, &ts);
     }
 
-    if (err == 0) {
+    bool acquired = (counter_ > 0);
+    if (acquired) {
         counter_--;
     }
     mutex_.unlock();
 
-    // return false when err == ETIMEDOUT
-    return (err == 0);
+    return acquired;
 }
 
 void Semaphore::wait() {

--- a/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
+++ b/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
@@ -44,10 +44,10 @@ bool Semaphore::timed_wait(nanoseconds_t deadline) {
     }
 
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    deadline += (nanoseconds_t)ts.tv_sec * Second + (nanoseconds_t)ts.tv_nsec;
     ts.tv_sec = time_t(deadline / Second);
     ts.tv_nsec = long(deadline % Second);
+    // roc_log(LogDebug, "loop top, now=%lld, deadline=%lld",
+    // core::timestamp(core::ClockMonotonic), deadline);
 
     int err = 0;
     mutex_.lock();

--- a/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
+++ b/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
@@ -22,8 +22,20 @@ Semaphore::Semaphore(unsigned counter)
     : mutex_()
     , counter_(counter)
     , guard_(0) {
-    if (int err = pthread_cond_init(&cond_, NULL)) {
-        roc_panic("sem: pthread_cond_init(): %s", errno_to_str(err).c_str());
+    pthread_condattr_t attr;
+
+    if (int err = pthread_condattr_init(&attr)) {
+        roc_panic("semaphore: pthread_condattr_init(): %s", errno_to_str(err).c_str());
+    }
+    if (int err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC)) {
+        roc_panic("semaphore: pthread_condattr_setclock(): %s", errno_to_str(err).c_str());
+    }
+    if (int err = pthread_cond_init(&cond_, &attr)) {
+        roc_panic("semaphore: pthread_cond_init(): %s", errno_to_str(err).c_str());
+    }
+
+    if (int err = pthread_condattr_destroy(&attr)) {
+        roc_panic("semaphore: pthread_condattr_destroy(): %s", errno_to_str(err).c_str());
     }
 }
 

--- a/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
+++ b/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
@@ -96,15 +96,15 @@ bool Semaphore::timed_wait(nanoseconds_t deadline) {
             break;
         }
         nanoseconds_t timeout = deadline - now;
-        
+
         ts.tv_sec = time_t(timeout / Second);
         ts.tv_nsec = long(timeout % Second);
-        
+
         err = pthread_cond_timedwait_relative_np(&cond_, &mutex_.mutex_, &ts);
 #else
         ts.tv_sec = time_t(deadline / Second);
         ts.tv_nsec = long(deadline % Second);
-        
+
         err = pthread_cond_timedwait(&cond_, &mutex_.mutex_, &ts);
 #endif
     }

--- a/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
+++ b/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
@@ -27,10 +27,14 @@ Semaphore::Semaphore(unsigned counter)
     if (int err = pthread_condattr_init(&attr)) {
         roc_panic("semaphore: pthread_condattr_init(): %s", errno_to_str(err).c_str());
     }
+
+#if defined(CLOCK_MONOTONIC) && !defined(__APPLE__) && !defined(__MACH__)
     if (int err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC)) {
         roc_panic("semaphore: pthread_condattr_setclock(): %s",
                   errno_to_str(err).c_str());
     }
+#endif
+
     if (int err = pthread_cond_init(&cond_, &attr)) {
         roc_panic("semaphore: pthread_cond_init(): %s", errno_to_str(err).c_str());
     }
@@ -41,11 +45,34 @@ Semaphore::Semaphore(unsigned counter)
 }
 
 Semaphore::~Semaphore() {
+    /* Ensure that signal() and broadcast() are not using condvar.
+     */
     while (guard_) {
         cpu_relax();
     }
 
-    int err = 0;
+    int err;
+
+#if defined(__APPLE__) && defined(__MACH__)
+    if ((err = pthread_mutex_lock(&mutex_.mutex_))) {
+        roc_panic("mutex: pthread_mutex_lock(): %s", errno_to_str(err).c_str());
+    }
+
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 1;
+
+    err = pthread_cond_timedwait_relative_np(&cond_, &mutex_.mutex_, &ts);
+    if (err != 0 && err != ETIMEDOUT) {
+        roc_panic("mutex: pthread_cond_timedwait_relative_np(): %s",
+                  errno_to_str(err).c_str());
+    }
+
+    if ((err = pthread_mutex_unlock(&mutex_.mutex_))) {
+        roc_panic("mutex: pthread_mutex_unlock(): %s", errno_to_str(err).c_str());
+    }
+#endif
+
     if ((err = pthread_cond_destroy(&cond_))) {
         roc_panic("sem: pthread_cond_destroy(): %s", errno_to_str(err).c_str());
     }
@@ -57,15 +84,29 @@ bool Semaphore::timed_wait(nanoseconds_t deadline) {
     }
 
     struct timespec ts;
-    ts.tv_sec = time_t(deadline / Second);
-    ts.tv_nsec = long(deadline % Second);
-    // roc_log(LogDebug, "loop top, now=%lld, deadline=%lld",
-    // core::timestamp(core::ClockMonotonic), deadline);
-
     int err = 0;
+
     mutex_.lock();
     while (err == 0 && counter_ == 0) {
+#if defined(__APPLE__) && defined(__MACH__)
+        // On macOS, convert absolute deadline to relative timeout
+        nanoseconds_t now = timestamp(ClockMonotonic);
+        if (deadline <= now) {
+            err = ETIMEDOUT;
+            break;
+        }
+        nanoseconds_t timeout = deadline - now;
+        
+        ts.tv_sec = time_t(timeout / Second);
+        ts.tv_nsec = long(timeout % Second);
+        
+        err = pthread_cond_timedwait_relative_np(&cond_, &mutex_.mutex_, &ts);
+#else
+        ts.tv_sec = time_t(deadline / Second);
+        ts.tv_nsec = long(deadline % Second);
+        
         err = pthread_cond_timedwait(&cond_, &mutex_.mutex_, &ts);
+#endif
     }
 
     bool acquired = (counter_ > 0);
@@ -73,6 +114,10 @@ bool Semaphore::timed_wait(nanoseconds_t deadline) {
         counter_--;
     }
     mutex_.unlock();
+
+    if (err != 0 && err != ETIMEDOUT) {
+        roc_panic("semaphore: pthread_cond_timedwait(): %s", errno_to_str(err).c_str());
+    }
 
     return acquired;
 }

--- a/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
+++ b/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_core/semaphore.h"
+#include "roc_core/cpu_instructions.h"
+#include "roc_core/errno_to_str.h"
+#include "roc_core/log.h"
+#include "roc_core/panic.h"
+
+#include <errno.h>
+#include <time.h>
+
+namespace roc {
+namespace core {
+
+Semaphore::Semaphore(unsigned counter)
+    : mutex_()
+    , counter_(counter)
+    , guard_(0) {
+    if (int err = pthread_cond_init(&cond_, NULL)) {
+        roc_panic("sem: pthread_cond_init(): %s", errno_to_str(err).c_str());
+    }
+}
+
+Semaphore::~Semaphore() {
+    while (guard_) {
+        cpu_relax();
+    }
+
+    int err = 0;
+    if ((err = pthread_cond_destroy(&cond_))) {
+        roc_panic("sem: pthread_cond_destroy(): %s", errno_to_str(err).c_str());
+    }
+}
+
+bool Semaphore::timed_wait(nanoseconds_t deadline) {
+    if (deadline < 0) {
+        roc_panic("semaphore: unexpected negative deadline");
+    }
+
+    roc_log(roc::LogDebug, "origin time is %" PRId64 "\n", deadline);
+    roc_log(roc::LogDebug, "time is %" PRId64 "\n", deadline);
+    roc_log(roc::LogDebug, "now time is %" PRId64 "\n",
+            core::timestamp(core::ClockMonotonic));
+
+    struct timespec ts;
+    ts.tv_sec = time_t(deadline / Second);
+    ts.tv_nsec = long(deadline % Second);
+
+    int err = 0;
+    mutex_.lock();
+    while (err == 0 && counter_ == 0) {
+        err = pthread_cond_clockwait(&cond_, &mutex_.mutex_, CLOCK_MONOTONIC, &ts);
+        printf("finish waiting without sem");
+        // roc_log(roc::LogDebug, "finish waiting without sem");
+
+        if (err != 0 && err != ETIMEDOUT) {
+            roc_panic("semaphore: pthread_cond_timedwait(): %s",
+                      errno_to_str(err).c_str());
+        }
+    }
+
+    if (err == 0) {
+        counter_--;
+    }
+    mutex_.unlock();
+
+    // return false when err == ETIMEDOUT
+    return (err == 0);
+}
+
+void Semaphore::wait() {
+    int err = 0;
+    mutex_.lock();
+    while (err == 0 && counter_ == 0) {
+        if ((err = pthread_cond_wait(&cond_, &mutex_.mutex_))) {
+            roc_panic("semaphore: pthread_cond_wait(): %s", errno_to_str(err).c_str());
+        }
+    }
+    counter_--;
+    mutex_.unlock();
+}
+
+void Semaphore::post() {
+    ++guard_;
+    mutex_.lock();
+    counter_++;
+    if (int err = pthread_cond_broadcast(&cond_)) {
+        roc_panic("cond: pthread_cond_broadcast(): %s", errno_to_str(err).c_str());
+    }
+    mutex_.unlock();
+    --guard_;
+}
+
+} // namespace core
+} // namespace roc

--- a/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.h
+++ b/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.h
@@ -6,18 +6,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-//! @file roc_core/target_posix_ext/roc_core/semaphore.h
+//! @file roc_core/target_nosem/roc_core/semaphore.h
 //! @brief Semaphore.
 
 #ifndef ROC_CORE_SEMAPHORE_H_
 #define ROC_CORE_SEMAPHORE_H_
 
-#include "roc_core/atomic_int.h"
+#include "roc_core/atomic.h"
 #include "roc_core/attributes.h"
+#include "roc_core/mutex.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/time.h"
-
-#include <semaphore.h>
+#include <pthread.h>
 
 namespace roc {
 namespace core {
@@ -39,13 +39,14 @@ public:
     void wait();
 
     //! Increment counter and wake up blocked waits.
-    //! This method is lock-free at least on recent glibc and musl versions
-    //! (which implement POSIX semaphores using a futex and an atomic).
+    //! This method is implemented using mutex for platforms where
     void post();
 
 private:
-    sem_t sem_;
-    AtomicInt<int32_t> guard_;
+    pthread_cond_t cond_;
+    core::Mutex mutex_;
+    Atomic<unsigned> counter_;
+    Atomic<int> guard_;
 };
 
 } // namespace core

--- a/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.h
+++ b/src/internal_modules/roc_core/target_nosem/roc_core/semaphore.h
@@ -12,7 +12,7 @@
 #ifndef ROC_CORE_SEMAPHORE_H_
 #define ROC_CORE_SEMAPHORE_H_
 
-#include "roc_core/atomic.h"
+#include "roc_core/atomic_int.h"
 #include "roc_core/attributes.h"
 #include "roc_core/mutex.h"
 #include "roc_core/noncopyable.h"
@@ -45,8 +45,8 @@ public:
 private:
     pthread_cond_t cond_;
     core::Mutex mutex_;
-    Atomic<unsigned> counter_;
-    Atomic<int> guard_;
+    AtomicInt<unsigned> counter_;
+    AtomicInt<int> guard_;
 };
 
 } // namespace core

--- a/src/internal_modules/roc_core/target_posix/roc_core/mutex.h
+++ b/src/internal_modules/roc_core/target_posix/roc_core/mutex.h
@@ -70,6 +70,7 @@ public:
 
 private:
     friend class Cond;
+    friend class Semaphore;
 
     mutable pthread_mutex_t mutex_;
     mutable AtomicInt<int32_t> guard_;

--- a/src/internal_modules/roc_core/target_posix_sem/roc_core/semaphore.cpp
+++ b/src/internal_modules/roc_core/target_posix_sem/roc_core/semaphore.cpp
@@ -9,6 +9,7 @@
 #include "roc_core/semaphore.h"
 #include "roc_core/cpu_instructions.h"
 #include "roc_core/errno_to_str.h"
+#include "roc_core/log.h"
 #include "roc_core/panic.h"
 
 #include <errno.h>
@@ -34,16 +35,17 @@ Semaphore::~Semaphore() {
 }
 
 bool Semaphore::timed_wait(nanoseconds_t deadline) {
+    printf("Enter function of timed_wait");
     if (deadline < 0) {
         roc_panic("semaphore: unexpected negative deadline");
     }
 
-    for (;;) {
-        timespec ts;
-        ts.tv_sec = long(deadline / Second);
-        ts.tv_nsec = long(deadline % Second);
+    timespec ts;
+    ts.tv_sec = long(deadline / Second);
+    ts.tv_nsec = long(deadline % Second);
 
-        if (sem_timedwait(&sem_, &ts) == 0) {
+    for (;;) {
+        if (sem_clockwait(&sem_, CLOCK_MONOTONIC, &ts) == 0) {
             return true;
         }
 

--- a/src/internal_modules/roc_core/target_posix_sem/roc_core/semaphore.h
+++ b/src/internal_modules/roc_core/target_posix_sem/roc_core/semaphore.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_core/target_posix_sem/roc_core/semaphore.h
+//! @brief Semaphore.
+
+#ifndef ROC_CORE_SEMAPHORE_H_
+#define ROC_CORE_SEMAPHORE_H_
+
+#include "roc_core/atomic_int.h"
+#include "roc_core/attributes.h"
+#include "roc_core/noncopyable.h"
+#include "roc_core/time.h"
+
+#include <semaphore.h>
+
+namespace roc {
+namespace core {
+
+//! Semaphore.
+class Semaphore : public NonCopyable<> {
+public:
+    //! Initialize semaphore with given counter.
+    explicit Semaphore(unsigned counter = 0);
+
+    ~Semaphore();
+
+    //! Wait until the counter becomes non-zero, decrement it, and return true.
+    //! If deadline expires before the counter becomes non-zero, returns false.
+    //! Deadline should be in the same time domain as core::timestamp().
+    ROC_NODISCARD bool timed_wait(nanoseconds_t deadline);
+
+    //! Wait until the counter becomes non-zero, decrement it, and return.
+    void wait();
+
+    //! Increment counter and wake up blocked waits.
+    //! This method is lock-free at least on recent glibc and musl versions
+    //! (which implement POSIX semaphores using a futex and an atomic).
+    void post();
+
+private:
+    sem_t sem_;
+    AtomicInt<int32_t> guard_;
+};
+
+} // namespace core
+} // namespace roc
+
+#endif // ROC_CORE_SEMAPHORE_H_

--- a/src/internal_modules/roc_pipeline/state_tracker.cpp
+++ b/src/internal_modules/roc_pipeline/state_tracker.cpp
@@ -42,6 +42,7 @@ bool StateTracker::wait_state(unsigned int state_mask, core::nanoseconds_t deadl
 
     mutex_.lock();
     for (;;) {
+        //roc_log(LogDebug, "loop top, state=%d, now=%lld, deadline=%lld", get_state(), core::timestamp(core::ClockMonotonic), deadline);
         if (static_cast<unsigned>(get_state()) & state_mask) {
             mutex_.unlock();
             return true;

--- a/src/internal_modules/roc_pipeline/state_tracker.cpp
+++ b/src/internal_modules/roc_pipeline/state_tracker.cpp
@@ -19,7 +19,6 @@ StateTracker::StateTracker()
     , active_sessions_(0)
     , pending_packets_(0)
     , sem_is_occupied_(0)
-    , waiting_mask_(0)
     , mutex_()
     , waiting_con_(mutex_) {
 }
@@ -36,24 +35,24 @@ StateTracker::StateTracker()
 // Questions:
 // - When should the function return true vs false
 bool StateTracker::wait_state(unsigned int state_mask, core::nanoseconds_t deadline) {
-    
+    // If no state is specified in state_mask, return immediately
+    if (state_mask == 0) {
+        return true;
+    }
+
     mutex_.lock();
     for (;;) {
-        // If no state is specified in state_mask, return immediately
-        if (state_mask == 0) {
-            return true;
-        }
-
         if (static_cast<unsigned>(get_state()) & state_mask) {
+            mutex_.unlock();
             return true;
         }
 
         if (deadline >= 0 && deadline <= core::timestamp(core::ClockMonotonic)) {
+            mutex_.unlock();
             return false;
         }
 
         if (sem_is_occupied_.compare_exchange(0, 1)) {
-
             if (deadline >= 0) {
                 mutex_.unlock();
                 (void)sem_.timed_wait(deadline);

--- a/src/internal_modules/roc_pipeline/state_tracker.cpp
+++ b/src/internal_modules/roc_pipeline/state_tracker.cpp
@@ -42,7 +42,8 @@ bool StateTracker::wait_state(unsigned int state_mask, core::nanoseconds_t deadl
 
     mutex_.lock();
     for (;;) {
-        //roc_log(LogDebug, "loop top, state=%d, now=%lld, deadline=%lld", get_state(), core::timestamp(core::ClockMonotonic), deadline);
+        // roc_log(LogDebug, "loop top, state=%d, now=%lld, deadline=%lld", get_state(),
+        // core::timestamp(core::ClockMonotonic), deadline);
         if (static_cast<unsigned>(get_state()) & state_mask) {
             mutex_.unlock();
             return true;

--- a/src/internal_modules/roc_pipeline/state_tracker.cpp
+++ b/src/internal_modules/roc_pipeline/state_tracker.cpp
@@ -42,8 +42,8 @@ bool StateTracker::wait_state(unsigned int state_mask, core::nanoseconds_t deadl
 
     mutex_.lock();
     for (;;) {
-        // roc_log(LogDebug, "loop top, state=%d, now=%lld, deadline=%lld", get_state(),
-        // core::timestamp(core::ClockMonotonic), deadline);
+        roc_log(LogDebug, "loop top, state=%d, now=%lld, deadline=%lld", get_state(),
+        core::timestamp(core::ClockMonotonic), deadline);
         if (static_cast<unsigned>(get_state()) & state_mask) {
             mutex_.unlock();
             return true;

--- a/src/internal_modules/roc_pipeline/state_tracker.cpp
+++ b/src/internal_modules/roc_pipeline/state_tracker.cpp
@@ -42,8 +42,8 @@ bool StateTracker::wait_state(unsigned int state_mask, core::nanoseconds_t deadl
 
     mutex_.lock();
     for (;;) {
-        roc_log(LogDebug, "loop top, state=%d, now=%lld, deadline=%lld", get_state(),
-        core::timestamp(core::ClockMonotonic), deadline);
+        // roc_log(LogDebug, "loop top, state=%d, now=%lld, deadline=%lld", get_state(),
+        // core::timestamp(core::ClockMonotonic), deadline);
         if (static_cast<unsigned>(get_state()) & state_mask) {
             mutex_.unlock();
             return true;

--- a/src/internal_modules/roc_pipeline/state_tracker.cpp
+++ b/src/internal_modules/roc_pipeline/state_tracker.cpp
@@ -7,15 +7,74 @@
  */
 
 #include "roc_pipeline/state_tracker.h"
+#include "roc_core/log.h"
 #include "roc_core/panic.h"
 
 namespace roc {
 namespace pipeline {
 
 StateTracker::StateTracker()
-    : halt_state_(-1)
+    : sem_(0)
+    , halt_state_(-1)
     , active_sessions_(0)
-    , pending_packets_(0) {
+    , pending_packets_(0)
+    , sem_is_occupied_(0)
+    , waiting_mask_(0)
+    , mutex_()
+    , waiting_con_(mutex_) {
+}
+
+// StateTracker::~StateTracker() {
+//     mutex_.unlock();
+// }
+
+// This method should block until the state becomes any of the states specified by the
+// mask, or deadline expires. E.g. if mask is ACTIVE | PAUSED, it should block until state
+// becomes either ACTIVE or PAUSED. (Currently only two states are used, but later more
+// states will be needed). Deadline should be an absolute timestamp.
+
+// Questions:
+// - When should the function return true vs false
+bool StateTracker::wait_state(unsigned int state_mask, core::nanoseconds_t deadline) {
+    
+    mutex_.lock();
+    for (;;) {
+        // If no state is specified in state_mask, return immediately
+        if (state_mask == 0) {
+            return true;
+        }
+
+        if (static_cast<unsigned>(get_state()) & state_mask) {
+            return true;
+        }
+
+        if (deadline >= 0 && deadline <= core::timestamp(core::ClockMonotonic)) {
+            return false;
+        }
+
+        if (sem_is_occupied_.compare_exchange(0, 1)) {
+
+            if (deadline >= 0) {
+                mutex_.unlock();
+                (void)sem_.timed_wait(deadline);
+
+            } else {
+                mutex_.unlock();
+                sem_.wait();
+            }
+
+            mutex_.lock();
+            sem_is_occupied_ = 0;
+            waiting_con_.broadcast();
+
+        } else {
+            if (deadline >= 0) {
+                (void)waiting_con_.timed_wait(deadline);
+            } else {
+                waiting_con_.wait();
+            }
+        }
+    }
 }
 
 sndio::DeviceState StateTracker::get_state() const {
@@ -65,22 +124,50 @@ size_t StateTracker::num_sessions() const {
 }
 
 void StateTracker::register_session() {
-    active_sessions_++;
-}
-
-void StateTracker::unregister_session() {
-    if (--active_sessions_ < 0) {
-        roc_panic("state tracker: unpaired register/unregister session");
+    if (active_sessions_++ == 0) {
+        signal_state_change();
     }
 }
 
+void StateTracker::unregister_session() {
+    int prev_sessions = active_sessions_--;
+    if (prev_sessions == 0) {
+        roc_panic("state tracker: unpaired register/unregister session");
+    } else if (prev_sessions == 1 && pending_packets_ == 0) {
+        signal_state_change();
+    }
+
+    // if (--active_sessions_ < 0) {
+    //     roc_panic("state tracker: unpaired register/unregister session");
+    // }
+}
+
 void StateTracker::register_packet() {
-    pending_packets_++;
+    if (pending_packets_++ == 0 && active_sessions_ == 0) {
+        signal_state_change();
+    }
 }
 
 void StateTracker::unregister_packet() {
-    if (--pending_packets_ < 0) {
+    int prev_packets = pending_packets_--;
+    if (prev_packets == 0) {
         roc_panic("state tracker: unpaired register/unregister packet");
+    } else if (prev_packets == 1 && active_sessions_ == 0) {
+        signal_state_change();
+    }
+
+    // if (--pending_packets_ < 0) {
+    //     roc_panic("state tracker: unpaired register/unregister packet");
+    // }
+}
+
+void StateTracker::signal_state_change() {
+    // if (waiting_mask_ != 0 && (static_cast<unsigned>(get_state()) & waiting_mask_)) {
+    //     sem_.post();
+    // }
+    if (sem_is_occupied_) {
+        roc_log(LogDebug, "signaling");
+        sem_.post();
     }
 }
 

--- a/src/internal_modules/roc_pipeline/state_tracker.h
+++ b/src/internal_modules/roc_pipeline/state_tracker.h
@@ -12,7 +12,7 @@
 #ifndef ROC_PIPELINE_STATE_TRACKER_H_
 #define ROC_PIPELINE_STATE_TRACKER_H_
 
-#include "roc_core/atomic.h"
+#include "roc_core/atomic_int.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/semaphore.h"
 #include "roc_core/stddefs.h"
@@ -69,10 +69,10 @@ public:
 
 private:
     core::Semaphore sem_;
-    core::Atomic<int> halt_state_;
-    core::Atomic<int> active_sessions_;
-    core::Atomic<int> pending_packets_;
-    core::Atomic<int> sem_is_occupied_;
+    core::AtomicInt<int32_t> halt_state_;
+    core::AtomicInt<int32_t> active_sessions_;
+    core::AtomicInt<int32_t> pending_packets_;
+    core::AtomicInt<int32_t> sem_is_occupied_;
     core::Mutex mutex_;
     core::Cond waiting_con_;
 

--- a/src/internal_modules/roc_pipeline/state_tracker.h
+++ b/src/internal_modules/roc_pipeline/state_tracker.h
@@ -17,6 +17,7 @@
 #include "roc_core/semaphore.h"
 #include "roc_core/stddefs.h"
 #include "roc_core/time.h"
+#include "roc_core/cond.h"
 #include "roc_sndio/device_defs.h"
 
 namespace roc {

--- a/src/internal_modules/roc_pipeline/state_tracker.h
+++ b/src/internal_modules/roc_pipeline/state_tracker.h
@@ -13,11 +13,11 @@
 #define ROC_PIPELINE_STATE_TRACKER_H_
 
 #include "roc_core/atomic_int.h"
+#include "roc_core/cond.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/semaphore.h"
 #include "roc_core/stddefs.h"
 #include "roc_core/time.h"
-#include "roc_core/cond.h"
 #include "roc_sndio/device_defs.h"
 
 namespace roc {

--- a/src/internal_modules/roc_pipeline/state_tracker.h
+++ b/src/internal_modules/roc_pipeline/state_tracker.h
@@ -12,9 +12,11 @@
 #ifndef ROC_PIPELINE_STATE_TRACKER_H_
 #define ROC_PIPELINE_STATE_TRACKER_H_
 
-#include "roc_core/atomic_int.h"
+#include "roc_core/atomic.h"
 #include "roc_core/noncopyable.h"
+#include "roc_core/semaphore.h"
 #include "roc_core/stddefs.h"
+#include "roc_core/time.h"
 #include "roc_sndio/device_defs.h"
 
 namespace roc {
@@ -31,6 +33,9 @@ class StateTracker : public core::NonCopyable<> {
 public:
     //! Initialize all counters to zero.
     StateTracker();
+
+    //! Block until state becomes any of the ones specified by state_mask.
+    bool wait_state(unsigned state_mask, core::nanoseconds_t deadline);
 
     //! Compute current state.
     sndio::DeviceState get_state() const;
@@ -63,9 +68,16 @@ public:
     void unregister_packet();
 
 private:
-    core::AtomicInt<int32_t> halt_state_;
-    core::AtomicInt<int32_t> active_sessions_;
-    core::AtomicInt<int32_t> pending_packets_;
+    core::Semaphore sem_;
+    core::Atomic<int> halt_state_;
+    core::Atomic<int> active_sessions_;
+    core::Atomic<int> pending_packets_;
+    core::Atomic<int> sem_is_occupied_;
+    core::Atomic<unsigned> waiting_mask_;
+    core::Mutex mutex_;
+    core::Cond waiting_con_;
+
+    void signal_state_change();
 };
 
 } // namespace pipeline

--- a/src/internal_modules/roc_pipeline/state_tracker.h
+++ b/src/internal_modules/roc_pipeline/state_tracker.h
@@ -73,7 +73,6 @@ private:
     core::Atomic<int> active_sessions_;
     core::Atomic<int> pending_packets_;
     core::Atomic<int> sem_is_occupied_;
-    core::Atomic<unsigned> waiting_mask_;
     core::Mutex mutex_;
     core::Cond waiting_con_;
 

--- a/src/tests/roc_pipeline/test_semaphore.cpp
+++ b/src/tests/roc_pipeline/test_semaphore.cpp
@@ -139,7 +139,8 @@ TEST(semaphore, multiple_post_before_wait) {
 
     // All waits should succeed immediately without blocking
     for (int i = 0; i < 5; i++) {
-        bool result = sem.timed_wait(core::timestamp(core::ClockMonotonic));
+        bool result = sem.timed_wait(core::timestamp(core::ClockMonotonic)
+                                     + 100 * core::Millisecond);
         CHECK(result == true);
     }
 

--- a/src/tests/roc_pipeline/test_semaphore.cpp
+++ b/src/tests/roc_pipeline/test_semaphore.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "test_harness.h"
+
+#include "roc_address/protocol.h"
+#include "roc_audio/mixer.h"
+#include "roc_audio/sample.h"
+#include "roc_core/atomic.h"
+#include "roc_core/heap_arena.h"
+#include "roc_core/noop_arena.h"
+#include "roc_core/semaphore.h"
+#include "roc_core/thread.h"
+#include "roc_core/time.h"
+#include "roc_pipeline/config.h"
+#include "roc_pipeline/receiver_endpoint.h"
+#include "roc_pipeline/receiver_session_group.h"
+
+namespace roc {
+namespace pipeline {
+
+namespace {
+
+enum { PacketSz = 512 };
+
+core::HeapArena arena;
+
+packet::PacketFactory packet_factory(arena, PacketSz);
+audio::FrameFactory frame_factory(arena, PacketSz * sizeof(audio::sample_t));
+
+audio::ProcessorMap processor_map(arena);
+rtp::EncodingMap encoding_map(arena);
+
+class TestThread : public core::Thread {
+public:
+    TestThread(core::nanoseconds_t deadline, core::Semaphore* semaphore)
+        : r_(0)
+        , deadline_(deadline) {
+        semaphore_ = semaphore;
+    }
+
+    bool running() const {
+        return r_;
+    }
+
+    void wait_running() {
+        while (!r_) {
+            core::sleep_for(core::ClockMonotonic, core::Microsecond);
+        }
+    }
+
+private:
+    virtual void run() {
+        r_ = true;
+        semaphore_->timed_wait(deadline_);
+        r_ = false;
+    }
+    core::Atomic<int> r_;
+    core::nanoseconds_t deadline_;
+    core::Semaphore* semaphore_;
+};
+
+} // namespace
+
+TEST_GROUP(semaphore) {};
+
+TEST(semaphore, timeout_test) {
+    core::Semaphore sem(0);
+    roc_log(LogDebug, "ready");
+    bool result =
+        sem.timed_wait(1 * core::Second + core::timestamp(core::ClockMonotonic));
+    if (result) {
+        roc_log(LogDebug, "true, unlocked by other threads");
+    } else {
+        roc_log(LogDebug, "false, timeout");
+    }
+    CHECK(result == false);
+}
+
+TEST(semaphore, block_test) {
+    core::Semaphore sem(0);
+    roc_log(LogDebug, "ready");
+    TestThread** threads_ptr = new TestThread*[10];
+    for (int i = 0; i < 10; i++) {
+        threads_ptr[i] = new TestThread(
+            1 * core::Second + core::timestamp(core::ClockMonotonic), &sem);
+        threads_ptr[i]->start();
+    }
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 100);
+    for (int i = 0; i < 10; i++) {
+        CHECK(threads_ptr[i]->running());
+    }
+    for (int i = 0; i < 10; i++) {
+        sem.post();
+    }
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 100);
+    for (int i = 0; i < 10; i++) {
+        CHECK(!threads_ptr[i]->running());
+    }
+    for (int i = 0; i < 10; i++) {
+        threads_ptr[i]->join();
+    }
+}
+
+TEST(semaphore, multiple_post_before_wait) {
+    core::Semaphore sem(0);
+
+    // Post multiple times before any waits
+    for (int i = 0; i < 5; i++) {
+        sem.post();
+    }
+
+    // All waits should succeed immediately without blocking
+    for (int i = 0; i < 5; i++) {
+        bool result = sem.timed_wait(core::timestamp(core::ClockMonotonic));
+        CHECK(result == true);
+    }
+
+    // Next wait should timeout since counter is back to 0
+    bool result =
+        sem.timed_wait(100 * core::Millisecond + core::timestamp(core::ClockMonotonic));
+    CHECK(result == false);
+}
+
+TEST(semaphore, concurrent_post_and_wait) {
+    core::Semaphore sem(0);
+    const int num_threads = 20;
+    TestThread** threads_ptr = new TestThread*[num_threads];
+
+    // Start threads that will wait
+    for (int i = 0; i < num_threads; i++) {
+        threads_ptr[i] = new TestThread(
+            1 * core::Second + core::timestamp(core::ClockMonotonic), &sem);
+        threads_ptr[i]->start();
+    }
+
+    // Wait for all threads to be running and blocked
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 100);
+    for (int i = 0; i < num_threads; i++) {
+        CHECK(threads_ptr[i]->running());
+    }
+
+    // Post from multiple iterations to wake them up gradually
+    for (int i = 0; i < num_threads; i++) {
+        sem.post();
+    }
+
+    // All threads should eventually finish
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 200);
+    for (int i = 0; i < num_threads; i++) {
+        CHECK(!threads_ptr[i]->running());
+    }
+
+    for (int i = 0; i < num_threads; i++) {
+        threads_ptr[i]->join();
+    }
+}
+
+} // namespace pipeline
+} // namespace roc

--- a/src/tests/roc_pipeline/test_semaphore.cpp
+++ b/src/tests/roc_pipeline/test_semaphore.cpp
@@ -89,43 +89,43 @@ TEST(semaphore, timeout_test) {
 TEST(semaphore, block_test) {
     core::Semaphore sem(0);
     roc_log(LogDebug, "ready");
-    
+
     // Use a vector or array of pointers that we'll clean up
     const int num_threads = 10;
     TestThread* threads[num_threads];
-    
+
     for (int i = 0; i < num_threads; i++) {
         threads[i] = new TestThread(
             2 * core::Second + core::timestamp(core::ClockMonotonic), &sem);
         (void)threads[i]->start();
     }
-    
+
     for (int i = 0; i < num_threads; i++) {
         (void)threads[i]->wait_running();
     }
     roc_log(LogDebug, "finish waiting running");
-    
+
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 100);
-    
+
     for (int i = 0; i < num_threads; i++) {
         CHECK(threads[i]->running());
     }
     roc_log(LogDebug, "finish checking running");
-    
+
     for (int i = 0; i < num_threads; i++) {
         sem.post();
     }
-    
+
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 300);
-    
+
     for (int i = 0; i < num_threads; i++) {
         CHECK(!threads[i]->running());
     }
     roc_log(LogDebug, "finish all finished running");
-    
+
     for (int i = 0; i < num_threads; i++) {
         threads[i]->join();
-        delete threads[i]; 
+        delete threads[i];
     }
 }
 
@@ -180,7 +180,7 @@ TEST(semaphore, concurrent_post_and_wait) {
 
     for (int i = 0; i < num_threads; i++) {
         threads[i]->join();
-        delete threads[i]; 
+        delete threads[i];
     }
 }
 

--- a/src/tests/roc_pipeline/test_semaphore.cpp
+++ b/src/tests/roc_pipeline/test_semaphore.cpp
@@ -11,7 +11,7 @@
 #include "roc_address/protocol.h"
 #include "roc_audio/mixer.h"
 #include "roc_audio/sample.h"
-#include "roc_core/atomic.h"
+#include "roc_core/atomic_int.h"
 #include "roc_core/heap_arena.h"
 #include "roc_core/noop_arena.h"
 #include "roc_core/semaphore.h"
@@ -60,7 +60,7 @@ private:
         semaphore_->timed_wait(deadline_);
         r_ = false;
     }
-    core::Atomic<int> r_;
+    core::AtomicInt<int32_t> r_;
     core::nanoseconds_t deadline_;
     core::Semaphore* semaphore_;
 };
@@ -88,17 +88,17 @@ TEST(semaphore, block_test) {
     TestThread** threads_ptr = new TestThread*[10];
     for (int i = 0; i < 10; i++) {
         threads_ptr[i] = new TestThread(
-            1 * core::Second + core::timestamp(core::ClockMonotonic), &sem);
+            2 * core::Second + core::timestamp(core::ClockMonotonic), &sem);
         threads_ptr[i]->start();
     }
-    core::sleep_for(core::ClockMonotonic, core::Millisecond * 100);
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 1000);
     for (int i = 0; i < 10; i++) {
         CHECK(threads_ptr[i]->running());
     }
     for (int i = 0; i < 10; i++) {
         sem.post();
     }
-    core::sleep_for(core::ClockMonotonic, core::Millisecond * 100);
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 300);
     for (int i = 0; i < 10; i++) {
         CHECK(!threads_ptr[i]->running());
     }

--- a/src/tests/roc_pipeline/test_semaphore.cpp
+++ b/src/tests/roc_pipeline/test_semaphore.cpp
@@ -57,7 +57,7 @@ public:
 private:
     virtual void run() {
         r_ = true;
-        semaphore_->timed_wait(deadline_);
+        (void)semaphore_->timed_wait(deadline_);
         r_ = false;
     }
     core::AtomicInt<int32_t> r_;
@@ -89,12 +89,17 @@ TEST(semaphore, block_test) {
     for (int i = 0; i < 10; i++) {
         threads_ptr[i] = new TestThread(
             2 * core::Second + core::timestamp(core::ClockMonotonic), &sem);
-        threads_ptr[i]->start();
+        (void)threads_ptr[i]->start();
     }
-    core::sleep_for(core::ClockMonotonic, core::Millisecond * 1000);
+    for (int i = 0; i < 10; i++) {
+        (void)threads_ptr[i]->wait_running();
+    }
+    roc_log(LogDebug, "finish waiting running");
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 100);
     for (int i = 0; i < 10; i++) {
         CHECK(threads_ptr[i]->running());
     }
+    roc_log(LogDebug, "finish checking running");
     for (int i = 0; i < 10; i++) {
         sem.post();
     }
@@ -102,6 +107,7 @@ TEST(semaphore, block_test) {
     for (int i = 0; i < 10; i++) {
         CHECK(!threads_ptr[i]->running());
     }
+    roc_log(LogDebug, "finish all finished running");
     for (int i = 0; i < 10; i++) {
         threads_ptr[i]->join();
     }
@@ -136,7 +142,7 @@ TEST(semaphore, concurrent_post_and_wait) {
     for (int i = 0; i < num_threads; i++) {
         threads_ptr[i] = new TestThread(
             1 * core::Second + core::timestamp(core::ClockMonotonic), &sem);
-        threads_ptr[i]->start();
+        (void)threads_ptr[i]->start();
     }
 
     // Wait for all threads to be running and blocked

--- a/src/tests/roc_pipeline/test_semaphore.cpp
+++ b/src/tests/roc_pipeline/test_semaphore.cpp
@@ -44,6 +44,10 @@ public:
         semaphore_ = semaphore;
     }
 
+    ~TestThread() {
+        join();
+    }
+
     bool running() const {
         return r_;
     }
@@ -85,31 +89,43 @@ TEST(semaphore, timeout_test) {
 TEST(semaphore, block_test) {
     core::Semaphore sem(0);
     roc_log(LogDebug, "ready");
-    TestThread** threads_ptr = new TestThread*[10];
-    for (int i = 0; i < 10; i++) {
-        threads_ptr[i] = new TestThread(
+    
+    // Use a vector or array of pointers that we'll clean up
+    const int num_threads = 10;
+    TestThread* threads[num_threads];
+    
+    for (int i = 0; i < num_threads; i++) {
+        threads[i] = new TestThread(
             2 * core::Second + core::timestamp(core::ClockMonotonic), &sem);
-        (void)threads_ptr[i]->start();
+        (void)threads[i]->start();
     }
-    for (int i = 0; i < 10; i++) {
-        (void)threads_ptr[i]->wait_running();
+    
+    for (int i = 0; i < num_threads; i++) {
+        (void)threads[i]->wait_running();
     }
     roc_log(LogDebug, "finish waiting running");
+    
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 100);
-    for (int i = 0; i < 10; i++) {
-        CHECK(threads_ptr[i]->running());
+    
+    for (int i = 0; i < num_threads; i++) {
+        CHECK(threads[i]->running());
     }
     roc_log(LogDebug, "finish checking running");
-    for (int i = 0; i < 10; i++) {
+    
+    for (int i = 0; i < num_threads; i++) {
         sem.post();
     }
+    
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 300);
-    for (int i = 0; i < 10; i++) {
-        CHECK(!threads_ptr[i]->running());
+    
+    for (int i = 0; i < num_threads; i++) {
+        CHECK(!threads[i]->running());
     }
     roc_log(LogDebug, "finish all finished running");
-    for (int i = 0; i < 10; i++) {
-        threads_ptr[i]->join();
+    
+    for (int i = 0; i < num_threads; i++) {
+        threads[i]->join();
+        delete threads[i]; 
     }
 }
 
@@ -136,19 +152,19 @@ TEST(semaphore, multiple_post_before_wait) {
 TEST(semaphore, concurrent_post_and_wait) {
     core::Semaphore sem(0);
     const int num_threads = 20;
-    TestThread** threads_ptr = new TestThread*[num_threads];
+    TestThread* threads[num_threads];
 
     // Start threads that will wait
     for (int i = 0; i < num_threads; i++) {
-        threads_ptr[i] = new TestThread(
+        threads[i] = new TestThread(
             1 * core::Second + core::timestamp(core::ClockMonotonic), &sem);
-        (void)threads_ptr[i]->start();
+        (void)threads[i]->start();
     }
 
     // Wait for all threads to be running and blocked
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 100);
     for (int i = 0; i < num_threads; i++) {
-        CHECK(threads_ptr[i]->running());
+        CHECK(threads[i]->running());
     }
 
     // Post from multiple iterations to wake them up gradually
@@ -159,11 +175,12 @@ TEST(semaphore, concurrent_post_and_wait) {
     // All threads should eventually finish
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 200);
     for (int i = 0; i < num_threads; i++) {
-        CHECK(!threads_ptr[i]->running());
+        CHECK(!threads[i]->running());
     }
 
     for (int i = 0; i < num_threads; i++) {
-        threads_ptr[i]->join();
+        threads[i]->join();
+        delete threads[i]; 
     }
 }
 

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -94,15 +94,15 @@ TEST(state_tracker, multiple_timeout) {
                                         core::timestamp(core::ClockMonotonic)
                                             + core::Millisecond * 5000);
     }
-    for (int i = 0; i < 10; i++) {
-        (void)threads_ptr[i]->wait_running();
-    }
 
     // wait for start, then check if threads are running
     for (int i = 0; i < 10; i++) {
         CHECK(threads_ptr[i]->start());
         // CHECK(threads_ptr[i]->running());
         // roc_log(LogDebug, "check running %d\n", i);
+    }
+    for (int i = 0; i < 10; i++) {
+        (void)threads_ptr[i]->wait_running();
     }
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 1000);
     for (int i = 0; i < 10; i++) {

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -78,6 +78,7 @@ TEST(state_tracker, simple_timeout) {
     TestThread thr(state_tracker, sndio::DeviceState_Active,
                    core::timestamp(core::ClockMonotonic) + core::Millisecond * 100);
 
+    (void)thr.wait_running();
     CHECK(thr.start());
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
     CHECK(!(thr.running()));
@@ -93,6 +94,9 @@ TEST(state_tracker, multiple_timeout) {
         threads_ptr[i] = new TestThread(state_tracker, sndio::DeviceState_Active,
                                         core::timestamp(core::ClockMonotonic)
                                             + core::Millisecond * 5000);
+    }
+    for (int i = 0; i < 10; i++) {
+        (void)threads_ptr[i]->wait_running();
     }
 
     // wait for start, then check if threads are running
@@ -138,11 +142,12 @@ TEST(state_tracker, multiple_switch) {
     for (int i = 0; i < 10; i++) {
         threads_ptr[i] = new TestThread(state_tracker, sndio::DeviceState_Active, -1);
     }
-
     for (int i = 0; i < 10; i++) {
         CHECK(threads_ptr[i]->start());
     }
-
+    for (int i = 0; i < 10; i++) {
+        (void)threads_ptr[i]->wait_running();
+    }
     roc_log(LogDebug, "started running");
 
     // wait for threads starting

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -85,19 +85,19 @@ TEST(state_tracker, simple_timeout) {
     (void)thr.wait_running();
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
     CHECK(!(thr.running()));
-    thr.join();  // Thread will be destroyed automatically when going out of scope
+    thr.join(); // Thread will be destroyed automatically when going out of scope
 }
 
 TEST(state_tracker, multiple_timeout) {
     StateTracker state_tracker;
     const int num_threads = 10;
     TestThread* threads[num_threads];
-    
+
     // set threads that last for 1 second
     for (int i = 0; i < num_threads; i++) {
         threads[i] = new TestThread(state_tracker, sndio::DeviceState_Active,
-                                        core::timestamp(core::ClockMonotonic)
-                                            + core::Millisecond * 5000);
+                                    core::timestamp(core::ClockMonotonic)
+                                        + core::Millisecond * 5000);
     }
 
     // wait for start, then check if threads are running
@@ -107,7 +107,7 @@ TEST(state_tracker, multiple_timeout) {
     for (int i = 0; i < num_threads; i++) {
         (void)threads[i]->wait_running();
     }
-    
+
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 1000);
     for (int i = 0; i < num_threads; i++) {
         CHECK(threads[i]->running());
@@ -131,24 +131,24 @@ TEST(state_tracker, multiple_timeout) {
     roc_log(LogDebug, "finished joining");
 
     for (int i = 0; i < num_threads; ++i) {
-        delete threads[i];  
+        delete threads[i];
     }
 }
 
 TEST(state_tracker, multiple_switch) {
     StateTracker state_tracker;
     const int num_threads = 10;
-    TestThread* threads[num_threads]; 
+    TestThread* threads[num_threads];
 
     // set threads without waiting time
     for (int i = 0; i < num_threads; i++) {
         threads[i] = new TestThread(state_tracker, sndio::DeviceState_Active, -1);
     }
-    
+
     for (int i = 0; i < num_threads; i++) {
         CHECK(threads[i]->start());
     }
-    
+
     for (int i = 0; i < num_threads; i++) {
         (void)threads[i]->wait_running();
     }
@@ -179,7 +179,7 @@ TEST(state_tracker, multiple_switch) {
     roc_log(LogDebug, "finished joining");
 
     for (int i = 0; i < num_threads; ++i) {
-        delete threads[i];  
+        delete threads[i];
     }
 }
 

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -11,7 +11,7 @@
 #include "roc_address/protocol.h"
 #include "roc_audio/mixer.h"
 #include "roc_audio/sample.h"
-#include "roc_core/atomic.h"
+#include "roc_core/atomic_int.h"
 #include "roc_core/heap_arena.h"
 #include "roc_core/noop_arena.h"
 #include "roc_core/semaphore.h"

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -45,6 +45,10 @@ public:
         , deadline_(deadline) {
     }
 
+    ~TestThread() {
+        join();
+    }
+
     bool running() const {
         return r_;
     }
@@ -81,33 +85,32 @@ TEST(state_tracker, simple_timeout) {
     (void)thr.wait_running();
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
     CHECK(!(thr.running()));
-    thr.join();
+    thr.join();  // Thread will be destroyed automatically when going out of scope
 }
 
 TEST(state_tracker, multiple_timeout) {
     StateTracker state_tracker;
-    TestThread** threads_ptr = new TestThread*[10];
-
+    const int num_threads = 10;
+    TestThread* threads[num_threads];
+    
     // set threads that last for 1 second
-    for (int i = 0; i < 10; i++) {
-        threads_ptr[i] = new TestThread(state_tracker, sndio::DeviceState_Active,
+    for (int i = 0; i < num_threads; i++) {
+        threads[i] = new TestThread(state_tracker, sndio::DeviceState_Active,
                                         core::timestamp(core::ClockMonotonic)
                                             + core::Millisecond * 5000);
     }
 
     // wait for start, then check if threads are running
-    for (int i = 0; i < 10; i++) {
-        CHECK(threads_ptr[i]->start());
-        // CHECK(threads_ptr[i]->running());
-        // roc_log(LogDebug, "check running %d\n", i);
+    for (int i = 0; i < num_threads; i++) {
+        CHECK(threads[i]->start());
     }
-    for (int i = 0; i < 10; i++) {
-        (void)threads_ptr[i]->wait_running();
+    for (int i = 0; i < num_threads; i++) {
+        (void)threads[i]->wait_running();
     }
+    
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 1000);
-    for (int i = 0; i < 10; i++) {
-        // roc_log(LogDebug, "check running %d\n", i);
-        CHECK(threads_ptr[i]->running());
+    for (int i = 0; i < num_threads; i++) {
+        CHECK(threads[i]->running());
     }
 
     // sleep for 2 seconds, making the threads timeout
@@ -115,37 +118,39 @@ TEST(state_tracker, multiple_timeout) {
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 5000);
 
     // check if threads are stopped
-    for (int i = 0; i < 10; i++) {
-        CHECK(!threads_ptr[i]->running());
+    for (int i = 0; i < num_threads; i++) {
+        CHECK(!threads[i]->running());
     }
 
     roc_log(LogDebug, "started joining");
 
-    for (int i = 0; i < 10; i++) {
-        threads_ptr[i]->join();
+    for (int i = 0; i < num_threads; i++) {
+        threads[i]->join();
     }
 
     roc_log(LogDebug, "finished joining");
 
-    for (int i = 0; i < 10; ++i) {
-        delete threads_ptr[i];
+    for (int i = 0; i < num_threads; ++i) {
+        delete threads[i];  
     }
-    delete[] threads_ptr;
 }
 
 TEST(state_tracker, multiple_switch) {
     StateTracker state_tracker;
-    TestThread** threads_ptr = new TestThread*[10];
+    const int num_threads = 10;
+    TestThread* threads[num_threads]; 
 
     // set threads without waiting time
-    for (int i = 0; i < 10; i++) {
-        threads_ptr[i] = new TestThread(state_tracker, sndio::DeviceState_Active, -1);
+    for (int i = 0; i < num_threads; i++) {
+        threads[i] = new TestThread(state_tracker, sndio::DeviceState_Active, -1);
     }
-    for (int i = 0; i < 10; i++) {
-        CHECK(threads_ptr[i]->start());
+    
+    for (int i = 0; i < num_threads; i++) {
+        CHECK(threads[i]->start());
     }
-    for (int i = 0; i < 10; i++) {
-        (void)threads_ptr[i]->wait_running();
+    
+    for (int i = 0; i < num_threads; i++) {
+        (void)threads[i]->wait_running();
     }
     roc_log(LogDebug, "started running");
 
@@ -153,8 +158,8 @@ TEST(state_tracker, multiple_switch) {
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
 
     // check if the threads have started
-    for (int i = 0; i < 10; i++) {
-        CHECK(threads_ptr[i]->running());
+    for (int i = 0; i < num_threads; i++) {
+        CHECK(threads[i]->running());
     }
 
     // register a packet
@@ -163,20 +168,20 @@ TEST(state_tracker, multiple_switch) {
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
 
     // check if the threads have been stopped
-    for (int i = 0; i < 10; i++) {
-        CHECK(!(threads_ptr[i]->running()));
+    for (int i = 0; i < num_threads; i++) {
+        CHECK(!(threads[i]->running()));
     }
 
     roc_log(LogDebug, "started joining");
-    for (int i = 0; i < 10; i++) {
-        threads_ptr[i]->join();
+    for (int i = 0; i < num_threads; i++) {
+        threads[i]->join();
     }
     roc_log(LogDebug, "finished joining");
 
-    for (int i = 0; i < 10; ++i) {
-        delete threads_ptr[i];
+    for (int i = 0; i < num_threads; ++i) {
+        delete threads[i];  
     }
-    delete[] threads_ptr;
 }
+
 } // namespace pipeline
 } // namespace roc

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2023 Roc Streaming authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "test_harness.h"
+
+#include "roc_address/protocol.h"
+#include "roc_audio/mixer.h"
+#include "roc_audio/sample.h"
+#include "roc_core/atomic.h"
+#include "roc_core/heap_arena.h"
+#include "roc_core/noop_arena.h"
+#include "roc_core/semaphore.h"
+#include "roc_core/thread.h"
+#include "roc_core/time.h"
+#include "roc_pipeline/config.h"
+#include "roc_pipeline/receiver_endpoint.h"
+#include "roc_pipeline/receiver_session_group.h"
+
+namespace roc {
+namespace pipeline {
+
+namespace {
+
+enum { PacketSz = 512 };
+
+core::HeapArena arena;
+
+packet::PacketFactory packet_factory(arena, PacketSz);
+audio::FrameFactory frame_factory(arena, PacketSz * sizeof(audio::sample_t));
+
+audio::ProcessorMap processor_map(arena);
+rtp::EncodingMap encoding_map(arena);
+
+class TestThread : public core::Thread {
+public:
+    TestThread(StateTracker& st, unsigned int state_mask, core::nanoseconds_t deadline)
+        : t_(st)
+        , r_(0)
+        , state_mask_(state_mask)
+        , deadline_(deadline) {
+    }
+
+    bool running() const {
+        return r_;
+    }
+
+    void wait_running() {
+        while (!r_) {
+            core::sleep_for(core::ClockMonotonic, core::Microsecond);
+        }
+    }
+
+private:
+    void run() {
+        r_ = true;
+        t_.wait_state(state_mask_, deadline_);
+        r_ = false;
+    }
+
+    StateTracker& t_;
+    core::Atomic<int> r_;
+    unsigned int state_mask_;
+    core::nanoseconds_t deadline_;
+};
+
+} // namespace
+
+TEST_GROUP(state_tracker) {};
+
+// set a thread that last for 0.5 seconds, wait for 1 second to make it timeout.
+TEST(state_tracker, simple_timeout) {
+    StateTracker state_tracker;
+    TestThread thr(state_tracker, sndio::DeviceState_Active,
+                   core::timestamp(core::ClockMonotonic) + core::Millisecond * 500);
+
+    CHECK(thr.start());
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 1000);
+    CHECK(!(thr.running()));
+    thr.join();
+}
+
+TEST(state_tracker, multiple_timeout) {
+    StateTracker state_tracker;
+    TestThread** threads_ptr = new TestThread*[10];
+
+    // set threads that last for 1 second
+    for (int i = 0; i < 10; i++) {
+        threads_ptr[i] = new TestThread(state_tracker, sndio::DeviceState_Active,
+                                        core::timestamp(core::ClockMonotonic)
+                                            + core::Millisecond * 1000);
+    }
+
+    // wait for start, then check if threads are running
+    for (int i = 0; i < 10; i++) {
+        CHECK(threads_ptr[i]->start());
+        // CHECK(threads_ptr[i]->running());
+        // roc_log(LogDebug, "check running %d\n", i);
+    }
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 10);
+    for (int i = 0; i < 10; i++) {
+        // roc_log(LogDebug, "check running %d\n", i);
+        CHECK(threads_ptr[i]->running());
+    }
+
+    // sleep for 2 seconds, making the threads timeout
+    roc_log(LogDebug, "started running");
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 2000);
+
+    // check if threads are stopped
+    for (int i = 0; i < 10; i++) {
+        CHECK(!threads_ptr[i]->running());
+    }
+
+    roc_log(LogDebug, "started joining");
+
+    for (int i = 0; i < 10; i++) {
+        threads_ptr[i]->join();
+    }
+
+    roc_log(LogDebug, "finished joining");
+
+    for (int i = 0; i < 10; ++i) {
+        delete threads_ptr[i];
+    }
+    delete[] threads_ptr;
+}
+
+TEST(state_tracker, multiple_switch) {
+    StateTracker state_tracker;
+    TestThread** threads_ptr = new TestThread*[10];
+
+    // set threads without waiting time
+    for (int i = 0; i < 10; i++) {
+        threads_ptr[i] = new TestThread(state_tracker, sndio::DeviceState_Active, -1);
+    }
+
+    for (int i = 0; i < 10; i++) {
+        CHECK(threads_ptr[i]->start());
+    }
+
+    roc_log(LogDebug, "started running");
+
+    // wait for threads starting
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
+
+    // check if the threads have started
+    for (int i = 0; i < 10; i++) {
+        CHECK(threads_ptr[i]->running());
+    }
+
+    // register a packet
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
+    state_tracker.register_packet();
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
+
+    // check if the threads have been stopped
+    for (int i = 0; i < 10; i++) {
+        CHECK(!(threads_ptr[i]->running()));
+    }
+
+    roc_log(LogDebug, "started joining");
+    for (int i = 0; i < 10; i++) {
+        threads_ptr[i]->join();
+    }
+    roc_log(LogDebug, "finished joining");
+
+    for (int i = 0; i < 10; ++i) {
+        delete threads_ptr[i];
+    }
+    delete[] threads_ptr;
+}
+} // namespace pipeline
+} // namespace roc

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -63,7 +63,7 @@ private:
     }
 
     StateTracker& t_;
-    core::Atomic<int> r_;
+    core::AtomicInt<int32_t> r_;
     unsigned int state_mask_;
     core::nanoseconds_t deadline_;
 };

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -77,9 +77,8 @@ TEST(state_tracker, simple_timeout) {
     StateTracker state_tracker;
     TestThread thr(state_tracker, sndio::DeviceState_Active,
                    core::timestamp(core::ClockMonotonic) + core::Millisecond * 100);
-
-    (void)thr.wait_running();
     CHECK(thr.start());
+    (void)thr.wait_running();
     core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
     CHECK(!(thr.running()));
     thr.join();

--- a/src/tests/roc_pipeline/test_state_tracker.cpp
+++ b/src/tests/roc_pipeline/test_state_tracker.cpp
@@ -76,10 +76,10 @@ TEST_GROUP(state_tracker) {};
 TEST(state_tracker, simple_timeout) {
     StateTracker state_tracker;
     TestThread thr(state_tracker, sndio::DeviceState_Active,
-                   core::timestamp(core::ClockMonotonic) + core::Millisecond * 500);
+                   core::timestamp(core::ClockMonotonic) + core::Millisecond * 100);
 
     CHECK(thr.start());
-    core::sleep_for(core::ClockMonotonic, core::Millisecond * 1000);
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 500);
     CHECK(!(thr.running()));
     thr.join();
 }
@@ -92,7 +92,7 @@ TEST(state_tracker, multiple_timeout) {
     for (int i = 0; i < 10; i++) {
         threads_ptr[i] = new TestThread(state_tracker, sndio::DeviceState_Active,
                                         core::timestamp(core::ClockMonotonic)
-                                            + core::Millisecond * 1000);
+                                            + core::Millisecond * 5000);
     }
 
     // wait for start, then check if threads are running
@@ -101,7 +101,7 @@ TEST(state_tracker, multiple_timeout) {
         // CHECK(threads_ptr[i]->running());
         // roc_log(LogDebug, "check running %d\n", i);
     }
-    core::sleep_for(core::ClockMonotonic, core::Millisecond * 10);
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 1000);
     for (int i = 0; i < 10; i++) {
         // roc_log(LogDebug, "check running %d\n", i);
         CHECK(threads_ptr[i]->running());
@@ -109,7 +109,7 @@ TEST(state_tracker, multiple_timeout) {
 
     // sleep for 2 seconds, making the threads timeout
     roc_log(LogDebug, "started running");
-    core::sleep_for(core::ClockMonotonic, core::Millisecond * 2000);
+    core::sleep_for(core::ClockMonotonic, core::Millisecond * 5000);
 
     // check if threads are stopped
     for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
Follow-up PR of my previous PR https://github.com/roc-streaming/roc-toolkit/issues/749
Implement [StateTracker::wait_state() with lock-free wakeup ](https://github.com/roc-streaming/roc-toolkit/issues/749) and Implement a semaphore using condvar and mutex

Detail:
1. Make the Waiting Threads waiting using condition variables
2. Add compile time check in SConstruct for whether sem_clockedwait exists
3. Add fall-back semaphore using cond var and mutex for platforms without sem_clockedwait (reason explained here https://github.com/roc-streaming/roc-toolkit/pull/814#discussion_r2131635054)
5. Add test cases of state_tracker's timeout and blocking.
6. Add test cases of semaphore