### PR TITLE
cli tools: enable multi channels io- and packet- encodings args

### DIFF
--- a/src/internal_modules/roc_audio/sample_spec_parse.rl
+++ b/src/internal_modules/roc_audio/sample_spec_parse.rl
@@ -298,9 +298,10 @@ bool parse_sample_spec_imp(const char* str, SampleSpec& sample_spec) {
             sample_spec.set_sample_rate(rate);
         }
 
+        delimiter = [,_\.] | space;
         surround_mask = ([a-z] [a-z0-9.]+) >start_token %set_surround_mask;
         surround_channel = [A-Z]+ >start_token %set_surround_channel;
-        surround_list = surround_channel (',' surround_channel)*;
+        surround_list = surround_channel (delimiter surround_channel)*;
 
         surround = (surround_mask | surround_list) %set_surround;
 
@@ -312,15 +313,14 @@ bool parse_sample_spec_imp(const char* str, SampleSpec& sample_spec) {
         mtr_range_end = [0-9]+ >start_token %set_mtr_range_end;
         mtr_range = (mtr_range_begin '-' mtr_range_end) >start_token %set_mtr_range;
         mtr_channel = mtr_number | mtr_range;
-        mtr_list = mtr_channel (',' mtr_channel)*;
+        mtr_list = mtr_channel (delimiter mtr_channel)*;
 
         mtr = (mtr_mask | mtr_list) %set_mtr;
 
         format = [a-z0-9_]+ >start_token %set_format;
         subformat = [a-z0-9_]+ >start_token %set_subformat;
         rate = [0-9]+ >start_token %set_rate;
-        channels_DISABLED = surround | mtr;
-        channels = ('stereo' | 'mono') >start_token %set_surround_mask %set_surround;
+        channels = surround | mtr;
 
         main := ( ('-' | format ('@' subformat)?) '/' ('-' | rate) '/' ('-' | channels) )
                 %{ success = true; }

--- a/src/tests/roc_audio/test_sample_spec.cpp
+++ b/src/tests/roc_audio/test_sample_spec.cpp
@@ -471,7 +471,7 @@ TEST(sample_spec, parse_format) {
     }
 }
 
-IGNORE_TEST(sample_spec, parse_channels) {
+TEST(sample_spec, parse_channels) {
     { // surround stereo
         SampleSpec sample_spec;
         CHECK(parse_sample_spec("pcm@s16/48000/stereo", sample_spec));

--- a/src/tests/roc_rtp/test_encoding.cpp
+++ b/src/tests/roc_rtp/test_encoding.cpp
@@ -15,7 +15,7 @@ namespace rtp {
 
 TEST_GROUP(encoding) {};
 
-IGNORE_TEST(encoding, parse) {
+TEST(encoding, parse) {
     Encoding enc;
     CHECK(parse_encoding("101:pcm@s18/48000/surround4.1", enc));
 


### PR DESCRIPTION
gengetopt intervents into parsing packet-encoding by splitting comma-separated channels set into array, e.g. 100:pcm@s16/44100/FL,FR
  [0]: 100:pcm@s16/44100/FL
  [1]: FR

Here is a proposition to allow other channels list separator such as ',._ ', e.g.:
--packet-encoding=100:pcm/4800/stereo,"101:pcm/48000/FL FR BL BR"