### PR TITLE
cli tools: fix frame size estimation when frame_length isn't provided

### DIFF
--- a/src/internal_modules/roc_audio/profiler.h
+++ b/src/internal_modules/roc_audio/profiler.h
@@ -21,6 +21,7 @@
 #include "roc_core/rate_limiter.h"
 #include "roc_core/time.h"
 #include "roc_packet/units.h"
+#include "roc_sndio/io_config.h"
 #include "roc_status/code_to_str.h"
 
 namespace roc {
@@ -32,7 +33,7 @@ struct ProfilerConfig {
     //! Default Initialization.
     ProfilerConfig()
         : profiling_interval(core::Second)
-        , chunk_duration(10 * core::Millisecond) {
+        , chunk_duration(sndio::DefaultFrameLength) {
     }
 
     //! Override Initialization.

--- a/src/internal_modules/roc_sndio/io_config.h
+++ b/src/internal_modules/roc_sndio/io_config.h
@@ -20,6 +20,15 @@
 namespace roc {
 namespace sndio {
 
+namespace {
+
+//! Default duration of a frame. 10ms is rather high,
+//! but works well even on cheap sound cards and CPUs.
+//! Usually you can use much lower values.
+const core::nanoseconds_t DefaultFrameLength = 10 * core::Millisecond;
+
+} // namespace
+
 //! Sink and source config.
 struct IoConfig {
     //! Sample spec

--- a/src/internal_modules/roc_sndio/io_pump.cpp
+++ b/src/internal_modules/roc_sndio/io_pump.cpp
@@ -14,12 +14,6 @@
 namespace roc {
 namespace sndio {
 
-namespace {
-
-const core::nanoseconds_t DefaultFrameLength = 10 * core::Millisecond;
-
-} // namespace
-
 IoPump::IoPump(core::IPool& frame_pool,
                core::IPool& frame_buffer_pool,
                ISource& source,

--- a/src/internal_modules/roc_sndio/target_pulseaudio/roc_sndio/pulseaudio_device.cpp
+++ b/src/internal_modules/roc_sndio/target_pulseaudio/roc_sndio/pulseaudio_device.cpp
@@ -27,10 +27,6 @@ const core::nanoseconds_t ReportInterval = 10 * core::Second;
 // 40ms or 20ms, and sometimes even 10ms
 const core::nanoseconds_t DefaultLatency = core::Millisecond * 60;
 
-// 10ms is rather high, but works well even on cheap sound cards and CPUs.
-// Usually you can use much lower values.
-const core::nanoseconds_t DefaultFrameLength = 10 * core::Millisecond;
-
 const core::nanoseconds_t MinTimeout = core::Millisecond * 50;
 const core::nanoseconds_t MaxTimeout = core::Second * 2;
 

--- a/src/internal_modules/roc_sndio/target_sox/roc_sndio/sox_sink.cpp
+++ b/src/internal_modules/roc_sndio/target_sox/roc_sndio/sox_sink.cpp
@@ -16,12 +16,6 @@
 namespace roc {
 namespace sndio {
 
-namespace {
-
-const core::nanoseconds_t DefaultFrameLength = 10 * core::Millisecond;
-
-} // namespace
-
 SoxSink::SoxSink(audio::FrameFactory& frame_factory,
                  core::IArena& arena,
                  const IoConfig& io_config,

--- a/src/internal_modules/roc_sndio/target_sox/roc_sndio/sox_source.cpp
+++ b/src/internal_modules/roc_sndio/target_sox/roc_sndio/sox_source.cpp
@@ -16,12 +16,6 @@
 namespace roc {
 namespace sndio {
 
-namespace {
-
-const core::nanoseconds_t DefaultFrameLength = 10 * core::Millisecond;
-
-} // namespace
-
 SoxSource::SoxSource(audio::FrameFactory& frame_factory,
                      core::IArena& arena,
                      const IoConfig& io_config,

--- a/src/tools/roc_copy/main.cpp
+++ b/src/tools/roc_copy/main.cpp
@@ -124,7 +124,12 @@ size_t compute_max_frame_size(const sndio::IoConfig& io_config) {
                       audio::ChanLayout_Surround, audio::ChanOrder_Smpte,
                       audio::ChanMask_Surround_7_1_4, 48000);
 
-    return spec.ns_2_samples_overall(io_config.frame_length) * sizeof(audio::sample_t);
+    core::nanoseconds_t len = io_config.frame_length;
+    if (len == 0) {
+        len = 10 * core::Millisecond;
+    }
+
+    return spec.ns_2_samples_overall(len) * sizeof(audio::sample_t);
 }
 
 bool parse_input_uri(const gengetopt_args_info& args, address::IoUri& input_uri) {

--- a/src/tools/roc_copy/main.cpp
+++ b/src/tools/roc_copy/main.cpp
@@ -126,7 +126,7 @@ size_t compute_max_frame_size(const sndio::IoConfig& io_config) {
 
     core::nanoseconds_t len = io_config.frame_length;
     if (len == 0) {
-        len = 10 * core::Millisecond;
+        len = sndio::DefaultFrameLength;
     }
 
     return spec.ns_2_samples_overall(len) * sizeof(audio::sample_t);

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -110,7 +110,7 @@ bool build_context_config(const gengetopt_args_info& args,
                           audio::ChanMask_Surround_7_1_4, 48000);
         core::nanoseconds_t len = io_config.frame_length;
         if (len == 0) {
-            len = 10 * core::Millisecond;
+            len = sndio::DefaultFrameLength;
         }
         context_config.max_frame_size =
             spec.ns_2_samples_overall(len) * sizeof(audio::sample_t);

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -113,6 +113,17 @@ bool build_context_config(const gengetopt_args_info& args,
             roc_log(LogError, "invalid --max-frame-size: should be > 0");
             return false;
         }
+    } else {
+        audio::SampleSpec spec = io_config.sample_spec;
+        spec.use_defaults(audio::Format_Pcm, audio::PcmSubformat_Raw,
+                          audio::ChanLayout_Surround, audio::ChanOrder_Smpte,
+                          audio::ChanMask_Surround_7_1_4, 48000);
+        core::nanoseconds_t len = io_config.frame_length;
+        if (len == 0) {
+            len = 10 * core::Millisecond;
+        }
+        context_config.max_frame_size =
+            spec.ns_2_samples_overall(len) * sizeof(audio::sample_t);
     }
 
     return true;

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -98,7 +98,7 @@ bool build_context_config(const gengetopt_args_info& args,
                           audio::ChanMask_Surround_7_1_4, 48000);
         core::nanoseconds_t len = io_config.frame_length;
         if (len == 0) {
-            len = 10 * core::Millisecond;
+            len = sndio::DefaultFrameLength;
         }
         context_config.max_packet_size =
             packet::Packet::approx_size(spec.ns_2_samples_overall(len));
@@ -120,7 +120,7 @@ bool build_context_config(const gengetopt_args_info& args,
                           audio::ChanMask_Surround_7_1_4, 48000);
         core::nanoseconds_t len = io_config.frame_length;
         if (len == 0) {
-            len = 10 * core::Millisecond;
+            len = sndio::DefaultFrameLength;
         }
         context_config.max_frame_size =
             spec.ns_2_samples_overall(len) * sizeof(audio::sample_t);


### PR DESCRIPTION
In multi channel scenario a frame sz become too big and Frame Factory refuses to allocate frames. Here the max frame size is estimated similar way to max packet sz estimation.

gh-821