### PR TITLE
fix #821: raise default max_packet_size for multitrack support

### DIFF
--- a/src/internal_modules/roc_audio/packetizer.cpp
+++ b/src/internal_modules/roc_audio/packetizer.cpp
@@ -185,7 +185,12 @@ packet::PacketPtr Packetizer::create_packet_() {
     }
 
     if (!composer_.prepare(*packet, buffer, payload_size_)) {
-        roc_log(LogError, "packetizer: can't prepare packet");
+        roc_log(LogError,
+                "packetizer: can't prepare packet:"
+                " packet buffer is too small for the requested payload:"
+                " payload_size=%lu buffer_capacity=%lu"
+                " (increase max_packet_size in context config)",
+                (unsigned long)payload_size_, (unsigned long)buffer.capacity());
         return NULL;
     }
     packet->add_flags(packet::Packet::FlagPrepared);

--- a/src/internal_modules/roc_node/context.h
+++ b/src/internal_modules/roc_node/context.h
@@ -35,7 +35,7 @@ struct ContextConfig {
     size_t max_frame_size;
 
     ContextConfig()
-        : max_packet_size(2048)
+        : max_packet_size(16384)
         , max_frame_size(4096) {
     }
 };


### PR DESCRIPTION
Fixes #821

The default `max_packet_size` of 2048 bytes is too small for multitrack
audio. For example, 8 channels at 48kHz with the default 5ms packet
length requires ~3904 bytes (240 samples × 8 channels × 2 bytes + RTP
header), causing the packetizer to silently fail with "can't prepare packet".

Changes:
- Raise `ContextConfig` default `max_packet_size` from 2048 to 16384 bytes,
  which covers up to ~34 channels at 48kHz/5ms/16-bit PCM without any
  manual configuration
- Improve the error message in `Packetizer::create_packet_()` to include
  `payload_size` and `buffer_capacity`, and hint the user to increase
  `max_packet_size` if they do hit the limit
