### PR TITLE
fix #807: add --packet-encoding option to roc-send

### DIFF
--- a/src/tools/roc_send/cmdline.ggo
+++ b/src/tools/roc_send/cmdline.ggo
@@ -50,6 +50,9 @@ section "Options"
     option "rate" - "Override input sample rate, Hz"
         int optional
 
+    option "packet-encoding" - "Register custom packet encoding (e.g. \"96:s16/48000/stereo\")"
+        typestr="ENCODING" string optional
+
     option "latency-backend" - "Which latency to use in latency tuner"
         values="niq" default="niq" enum optional
 

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -20,6 +20,7 @@
 #include "roc_node/context.h"
 #include "roc_node/sender.h"
 #include "roc_pipeline/sender_sink.h"
+#include "roc_rtp/encoding.h"
 #include "roc_sndio/backend_dispatcher.h"
 #include "roc_sndio/backend_map.h"
 #include "roc_sndio/print_supported.h"
@@ -266,6 +267,22 @@ int main(int argc, char** argv) {
     if (!context.is_valid()) {
         roc_log(LogError, "can't initialize node context");
         return 1;
+    }
+
+    if (args.packet_encoding_given) {
+        rtp::Encoding enc;
+        if (!rtp::parse_encoding(args.packet_encoding_arg, enc)) {
+            roc_log(LogError,
+                    "invalid --packet-encoding: bad format,"
+                    " expected \"<id>:<format>/<rate>/<channels>\","
+                    " e.g. \"96:s16/48000/stereo\"");
+            return 1;
+        }
+        if (!context.encoding_map().add_encoding(enc)) {
+            roc_log(LogError, "invalid --packet-encoding: failed to register encoding");
+            return 1;
+        }
+        sender_config.payload_type = enc.payload_type;
     }
 
     sndio::BackendDispatcher backend_dispatcher(context.arena());


### PR DESCRIPTION
The --rate flag only sets the input device sample rate, but the packet encoding defaults to L16_Stereo at 44100 Hz. When input rate differs from packet encoding rate, the sender creates a resampler even if the user doesn't want one.

Add --packet-encoding option that lets users register a custom RTP encoding and select it for outgoing packets. This allows sending at 48kHz (or any rate) without resampling:

  roc-send --rate=48000 --packet-encoding=96:s16/48000/stereo ...

The option accepts the format '<id>:<format>/<rate>/<channels>', e.g.:
  96:s16/48000/stereo
  97:s16/48000/mono

The encoding is registered in the context encoding map and the sender is configured to use it as the packet encoding.