### PR TITLE
Hot fix 4 Ubuntu 26.04: num of SoX drivers exceeds 256

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - script: linux-x86_64/ubuntu-26.04
+            image: rocstreaming/env-ubuntu:26.04
+
           - script: linux-x86_64/ubuntu-24.04
             image: rocstreaming/env-ubuntu:24.04
 

--- a/scripts/ci_checks/linux-x86_64/ubuntu-26.04.sh
+++ b/scripts/ci_checks/linux-x86_64/ubuntu-26.04.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+for comp in gcc-15 clang-21
+do
+    scons -Q \
+          --enable-werror \
+          --enable-tests \
+          --enable-benchmarks \
+          --enable-examples \
+          --build-3rdparty=openfec \
+          --compiler=${comp} \
+          test
+done

--- a/src/internal_modules/roc_sndio/driver.h
+++ b/src/internal_modules/roc_sndio/driver.h
@@ -21,7 +21,7 @@ namespace sndio {
 class IBackend;
 
 //! Maximum number of drivers.
-static const size_t MaxDrivers = 256;
+static const size_t MaxDrivers = 512;
 
 //! Driver type.
 enum DriverType {


### PR DESCRIPTION
fix #838 