### PR TITLE
CLI tools overwrite frame_length

### DIFF
--- a/src/tools/roc_copy/main.cpp
+++ b/src/tools/roc_copy/main.cpp
@@ -259,7 +259,9 @@ int main(int argc, char** argv) {
     }
 
     input_config.sample_spec = input_source->sample_spec();
-    input_config.frame_length = input_source->frame_length();
+    if (!args.io_frame_len_given) {
+        input_config.frame_length = input_source->frame_length();
+    }
 
     sndio::IoConfig output_config;
     if (!build_output_config(args, input_config, output_config)) {

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -653,7 +653,9 @@ int main(int argc, char** argv) {
     }
 
     io_config.sample_spec = output_sink->sample_spec();
-    io_config.frame_length = output_sink->frame_length();
+    if (!args.io_frame_len_given) {
+        io_config.frame_length = output_sink->frame_length();
+    }
 
     pipeline::ReceiverSourceConfig receiver_config;
     if (!build_receiver_config(args, receiver_config, context, *output_sink)) {

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -587,7 +587,9 @@ int main(int argc, char** argv) {
     }
 
     io_config.sample_spec = input_source->sample_spec();
-    io_config.frame_length = input_source->frame_length();
+    if (!args.io_frame_len_given) {
+        io_config.frame_length = input_source->frame_length();
+    }
 
     pipeline::SenderSinkConfig sender_config;
     if (!build_sender_config(args, sender_config, context, *input_source)) {


### PR DESCRIPTION
Fix this by checking if frame_length is configured by cli params.

Used to be like this:
<img width="800" height="511" alt="image" src="https://github.com/user-attachments/assets/9c0d3312-6415-4d5a-9dc2-a2464e4bb2b3" />

And now:
<img width="1084" height="666" alt="image" src="https://github.com/user-attachments/assets/5d6027a0-113a-4aa2-9a16-53ec7d2aff01" />
