### PR TITLE
Hot fix master

### DIFF
--- a/src/internal_modules/roc_address/target_posix/roc_address/socket_addr.cpp
+++ b/src/internal_modules/roc_address/target_posix/roc_address/socket_addr.cpp
@@ -149,7 +149,7 @@ bool SocketAddr::get_host(char* buf, size_t bufsz) const {
     return true;
 }
 
-SocketAddr::operator const struct unspecified_bool *() const {
+SocketAddr::operator const struct unspecified_bool*() const {
     return (const unspecified_bool*)has_host_port();
 }
 

--- a/src/internal_modules/roc_address/target_posix/roc_address/socket_addr.h
+++ b/src/internal_modules/roc_address/target_posix/roc_address/socket_addr.h
@@ -68,7 +68,7 @@ public:
     socklen_t max_slen() const;
 
     //! Convert to bool.
-    operator const struct unspecified_bool *() const;
+    operator const struct unspecified_bool*() const;
 
     //! Compare addresses.
     bool operator==(const SocketAddr& other) const;

--- a/src/internal_modules/roc_core/optional.h
+++ b/src/internal_modules/roc_core/optional.h
@@ -69,7 +69,7 @@ public:
     }
 
     //! Convert to bool.
-    operator const struct unspecified_bool *() const {
+    operator const struct unspecified_bool*() const {
         return (const unspecified_bool*)ptr_;
     }
 

--- a/src/internal_modules/roc_core/scoped_ptr.h
+++ b/src/internal_modules/roc_core/scoped_ptr.h
@@ -99,7 +99,7 @@ public:
     }
 
     //! Convert to bool.
-    operator const struct unspecified_bool *() const {
+    operator const struct unspecified_bool*() const {
         return (unspecified_bool*)ptr_;
     }
 

--- a/src/internal_modules/roc_core/shared_ptr.h
+++ b/src/internal_modules/roc_core/shared_ptr.h
@@ -111,7 +111,7 @@ public:
     }
 
     //! Convert to bool.
-    operator const struct unspecified_bool *() const {
+    operator const struct unspecified_bool*() const {
         return (const unspecified_bool*)ptr_;
     }
 

--- a/src/internal_modules/roc_core/slice.h
+++ b/src/internal_modules/roc_core/slice.h
@@ -201,7 +201,7 @@ public:
     //! Convert to bool.
     //! @returns
     //!  true if the slice is attached to buffer, even if it has zero length.
-    operator const struct unspecified_bool *() const {
+    operator const struct unspecified_bool*() const {
         return (const unspecified_bool*)data_;
     }
 

--- a/src/internal_modules/roc_rtp/headers.h
+++ b/src/internal_modules/roc_rtp/headers.h
@@ -135,7 +135,7 @@ public:
     //! Set version.
     void set_version(Version v) {
         roc_panic_if((v & Flag_VersionMask) != v);
-        flags_ &= (uint8_t) ~(Flag_VersionMask << Flag_VersionShift);
+        flags_ &= (uint8_t)~(Flag_VersionMask << Flag_VersionShift);
         flags_ |= ((uint8_t)v << Flag_VersionShift);
     }
 
@@ -146,7 +146,7 @@ public:
 
     //! Set padding flag.
     void set_padding(bool v) {
-        flags_ &= (uint8_t) ~(Flag_PaddingMask << Flag_PaddingShift);
+        flags_ &= (uint8_t)~(Flag_PaddingMask << Flag_PaddingShift);
         flags_ |= ((v ? 1 : 0) << Flag_PaddingShift);
     }
 
@@ -163,7 +163,7 @@ public:
     //! Set payload type.
     void set_payload_type(uint8_t pt) {
         roc_panic_if((pt & MPT_PayloadTypeMask) != pt);
-        mpt_ &= (uint8_t) ~(MPT_PayloadTypeMask << MPT_PayloadTypeShift);
+        mpt_ &= (uint8_t)~(MPT_PayloadTypeMask << MPT_PayloadTypeShift);
         mpt_ |= (pt << MPT_PayloadTypeShift);
     }
 
@@ -174,7 +174,7 @@ public:
 
     //! Set marker bit.
     void set_marker(bool m) {
-        mpt_ &= (uint8_t) ~(MPT_MarkerMask << MPT_MarkerShift);
+        mpt_ &= (uint8_t)~(MPT_MarkerMask << MPT_MarkerShift);
         mpt_ |= ((!!m) << MPT_MarkerShift);
     }
 

--- a/src/internal_modules/roc_sndio/target_sox/roc_sndio/sox_sink.cpp
+++ b/src/internal_modules/roc_sndio/target_sox/roc_sndio/sox_sink.cpp
@@ -168,6 +168,7 @@ void SoxSink::write(audio::Frame& frame) {
     SOX_SAMPLE_LOCALS;
 
     size_t clips = 0;
+    (void)clips;
 
     while (frame_size > 0) {
         for (; buffer_pos < buffer_size_ && frame_size > 0; buffer_pos++) {

--- a/src/tests/roc_rtp/test_timestamp_injector.cpp
+++ b/src/tests/roc_rtp/test_timestamp_injector.cpp
@@ -103,10 +103,11 @@ TEST(timestamp_injector, negative_and_positive_dn) {
 
     LONGS_EQUAL(0, queue.size());
     for (size_t i = 0; i < NPackets; i++) {
-        UNSIGNED_LONGS_EQUAL(status::StatusOK,
-                             queue.write(new_packet((packet::seqnum_t)i,
-                                                    (packet::stream_timestamp_t)(
-                                                        packet_rtp_ts + i * PacketSz))));
+        UNSIGNED_LONGS_EQUAL(
+            status::StatusOK,
+            queue.write(
+                new_packet((packet::seqnum_t)i,
+                           (packet::stream_timestamp_t)(packet_rtp_ts + i * PacketSz))));
     }
     LONGS_EQUAL(NPackets, queue.size());
 


### PR DESCRIPTION
Fix warning about unused an variable and 
supposedly should fix formatting. 

Formatting changed by update of clang-formatter to 21 version in ubuntu:latest container. Not sure if proper approach to reformat everything, but let's do to follow the established practice.

Goes into master in order to make CI green