### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - script: linux-x86_64/ubuntu-26.04
+            image: rocstreaming/env-ubuntu:26.04
+
           - script: linux-x86_64/ubuntu-24.04
             image: rocstreaming/env-ubuntu:24.04
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -430,26 +430,31 @@ jobs:
       matrix:
         include:
           - macos-arch: arm64
-            macos-version: 15
+            macos-version: 26
+            image: macos-26
             script: standard-build
 
           - macos-arch: arm64
-            macos-version: 15
+            macos-version: 26
+            image: macos-26
             script: build-3rdparty
 
           - macos-arch: arm64
-            macos-version: 15
+            macos-version: 26
+            image: macos-26
             script: universal-binaries
+
+          - macos-arch: x86_64
+            macos-version: 15
+            image: macos-15-intel
+            script: standard-build
 
           - macos-arch: arm64
             macos-version: 14
+            image: macos-14
             script: standard-build
 
-          - macos-arch: x86_64
-            macos-version: 13
-            script: standard-build
-
-    runs-on: macos-${{ matrix.macos-version }}
+    runs-on: ${{ matrix.image }}
 
     name: macos${{ matrix.macos-version }}-${{ matrix.macos-arch }}/${{ matrix.script }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,10 @@ __pycache__/
 /debian/roc
 
 # llm
+.aider/
 .aider.*
+.opencode
+.agent-shell
 
 # personal
 TODO.org

--- a/scripts/ci_checks/linux-x86_64/ubuntu-26.04.sh
+++ b/scripts/ci_checks/linux-x86_64/ubuntu-26.04.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+for comp in gcc-15 clang-21
+do
+    scons -Q \
+          --enable-werror \
+          --enable-tests \
+          --enable-benchmarks \
+          --enable-examples \
+          --build-3rdparty=openfec \
+          --compiler=${comp} \
+          test
+done

--- a/src/internal_modules/roc_netio/target_libuv/roc_netio/network_loop.cpp
+++ b/src/internal_modules/roc_netio/target_libuv/roc_netio/network_loop.cpp
@@ -53,6 +53,14 @@ NetworkLoop::Tasks::StartUdpRecv::StartUdpRecv(PortHandle handle,
     inbound_writer_ = &inbound_writer;
 }
 
+NetworkLoop::Tasks::StopUdpRecv::StopUdpRecv(PortHandle handle) {
+    func_ = &NetworkLoop::task_stop_udp_recv_;
+    if (!handle) {
+        roc_panic("network loop: port handle is null");
+    }
+    port_ = (BasicPort*)handle;
+}
+
 NetworkLoop::Tasks::AddTcpServerPort::AddTcpServerPort(TcpServerConfig& config,
                                                        IConnAcceptor& conn_acceptor) {
     func_ = &NetworkLoop::task_add_tcp_server_;
@@ -454,6 +462,26 @@ void NetworkLoop::task_start_udp_recv_(NetworkTask& base_task) {
 
     if (!port->start_recv(*task.inbound_writer_)) {
         roc_log(LogError, "network loop: can't start receiving on port %s",
+                task.port_->descriptor());
+        task.success_ = false;
+        task.state_ = NetworkTask::StateFinishing;
+        return;
+    }
+
+    task.success_ = true;
+    task.state_ = NetworkTask::StateFinishing;
+}
+
+void NetworkLoop::task_stop_udp_recv_(NetworkTask& base_task) {
+    Tasks::StopUdpRecv& task = (Tasks::StopUdpRecv&)base_task;
+
+    roc_log(LogDebug, "network loop: stopping receiving packets on port %s",
+            task.port_->descriptor());
+
+    core::SharedPtr<UdpPort> port = (UdpPort*)task.port_.get();
+
+    if (!port->stop_recv()) {
+        roc_log(LogError, "network loop: can't stop receiving on port %s",
                 task.port_->descriptor());
         task.success_ = false;
         task.state_ = NetworkTask::StateFinishing;

--- a/src/internal_modules/roc_netio/target_libuv/roc_netio/network_loop.h
+++ b/src/internal_modules/roc_netio/target_libuv/roc_netio/network_loop.h
@@ -111,6 +111,13 @@ public:
             packet::IWriter* inbound_writer_;
         };
 
+        //! Stop receiving on UDP port.
+        class StopUdpRecv : public NetworkTask {
+        public:
+            //! Set task parameters.
+            StopUdpRecv(PortHandle handle);
+        };
+
         //! Add TCP server port.
         class AddTcpServerPort : public NetworkTask {
         public:
@@ -242,6 +249,7 @@ private:
     void task_add_udp_port_(NetworkTask&);
     void task_start_udp_send_(NetworkTask&);
     void task_start_udp_recv_(NetworkTask&);
+    void task_stop_udp_recv_(NetworkTask&);
     void task_add_tcp_server_(NetworkTask&);
     void task_add_tcp_client_(NetworkTask&);
     void task_remove_port_(NetworkTask&);

--- a/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_port.cpp
+++ b/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_port.cpp
@@ -139,6 +139,8 @@ AsyncOperationStatus UdpPort::async_close(ICloseHandler& handler, void* handler_
 
     want_close_ = true;
 
+    inbound_writer_ = NULL;
+
     if (fully_closed_()) {
         return AsyncOp_Completed;
     }
@@ -190,6 +192,20 @@ bool UdpPort::start_recv(packet::IWriter& inbound_writer) {
     }
 
     inbound_writer_ = &inbound_writer;
+    return true;
+}
+
+bool UdpPort::stop_recv() {
+    if (recv_started_) {
+        if (int err = uv_udp_recv_stop(&handle_)) {
+            roc_log(LogError, "udp port: %s: uv_udp_recv_stop(): [%s] %s", descriptor(),
+                    uv_err_name(err), uv_strerror(err));
+            return false;
+        }
+        recv_started_ = false;
+    }
+
+    inbound_writer_ = NULL;
     return true;
 }
 

--- a/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_port.h
+++ b/src/internal_modules/roc_netio/target_libuv/roc_netio/udp_port.h
@@ -99,6 +99,11 @@ public:
     //!  Writer will be invoked from network thread.
     bool start_recv(packet::IWriter& inbound_writer);
 
+    //! Stop receiving packets.
+    //! @remarks
+    //!  After this call returns, writer won't be used anymore.
+    bool stop_recv();
+
 protected:
     //! Format descriptor.
     virtual void format_descriptor(core::StringBuilder& b);

--- a/src/internal_modules/roc_node/receiver.cpp
+++ b/src/internal_modules/roc_node/receiver.cpp
@@ -407,7 +407,29 @@ core::SharedPtr<Receiver::Slot> Receiver::get_slot_(slot_index_t slot_index,
 }
 
 void Receiver::cleanup_slot_(Slot& slot) {
-    // First remove network ports, because they write to pipeline slot.
+    // First stop receiving, because network ports may write to pipeline endpoints.
+    for (size_t p = 0; p < address::Iface_Max; p++) {
+        if (slot.ports[p].handle) {
+            netio::NetworkLoop::Tasks::StopUdpRecv task(slot.ports[p].handle);
+            if (!context().network_loop().schedule_and_wait(task)) {
+                roc_panic(
+                    "receiver node: can't stop receiving on network port of slot %lu",
+                    (unsigned long)slot.index);
+            }
+        }
+    }
+
+    // Then remove pipeline slot, because it writes to network ports.
+    if (slot.handle) {
+        pipeline::ReceiverLoop::Tasks::DeleteSlot task(slot.handle);
+        if (!pipeline_.schedule_and_wait(task)) {
+            roc_panic("receiver node: can't remove pipeline slot %lu",
+                      (unsigned long)slot.index);
+        }
+        slot.handle = NULL;
+    }
+
+    // Then remove network ports.
     for (size_t p = 0; p < address::Iface_Max; p++) {
         if (slot.ports[p].handle) {
             netio::NetworkLoop::Tasks::RemovePort task(slot.ports[p].handle);
@@ -417,16 +439,6 @@ void Receiver::cleanup_slot_(Slot& slot) {
             }
             slot.ports[p].handle = NULL;
         }
-    }
-
-    // Then remove pipeline slot.
-    if (slot.handle) {
-        pipeline::ReceiverLoop::Tasks::DeleteSlot task(slot.handle);
-        if (!pipeline_.schedule_and_wait(task)) {
-            roc_panic("receiver node: can't remove pipeline slot %lu",
-                      (unsigned long)slot.index);
-        }
-        slot.handle = NULL;
     }
 }
 

--- a/src/internal_modules/roc_node/sender.cpp
+++ b/src/internal_modules/roc_node/sender.cpp
@@ -245,6 +245,8 @@ bool Sender::connect(slot_index_t slot_index,
             break_slot_(*slot);
             return false;
         }
+
+        port.inbound_writer = endpoint_task.get_inbound_writer();
     }
 
     update_compatibility_(iface, uri);
@@ -469,7 +471,19 @@ core::SharedPtr<Sender::Slot> Sender::get_slot_(slot_index_t slot_index,
 }
 
 void Sender::cleanup_slot_(Slot& slot) {
-    // First remove pipeline slot, because it writes to network ports.
+    // First stop receiving, because network ports may write to pipeline endpoints.
+    for (size_t p = 0; p < address::Iface_Max; p++) {
+        if (slot.ports[p].handle && slot.ports[p].inbound_writer) {
+            netio::NetworkLoop::Tasks::StopUdpRecv task(slot.ports[p].handle);
+            if (!context().network_loop().schedule_and_wait(task)) {
+                roc_panic("sender node: can't stop receiving on network port of slot %lu",
+                          (unsigned long)slot.index);
+            }
+            slot.ports[p].inbound_writer = NULL;
+        }
+    }
+
+    // Then remove pipeline slot, because it writes to network ports.
     if (slot.handle) {
         pipeline::SenderLoop::Tasks::DeleteSlot task(slot.handle);
         if (!pipeline_.schedule_and_wait(task)) {

--- a/src/internal_modules/roc_node/sender.h
+++ b/src/internal_modules/roc_node/sender.h
@@ -98,10 +98,12 @@ private:
         netio::UdpConfig orig_config;
         netio::NetworkLoop::PortHandle handle;
         packet::IWriter* outbound_writer;
+        packet::IWriter* inbound_writer;
 
         Port()
             : handle(NULL)
-            , outbound_writer(NULL) {
+            , outbound_writer(NULL)
+            , inbound_writer(NULL) {
         }
     };
 

--- a/src/tests/public_api/test_loopback_encoder_2_decoder.cpp
+++ b/src/tests/public_api/test_loopback_encoder_2_decoder.cpp
@@ -302,9 +302,11 @@ TEST_GROUP(loopback_encoder_2_decoder) {
             if (ifaces[n_if] == ROC_INTERFACE_AUDIO_SOURCE) {
                 UNSIGNED_LONGS_EQUAL(iface_packets[n_if], recv_expected_pkts);
                 if (has_control) {
-                    const size_t nlag = test::FrameSamples / test::PacketSamples;
+                    const size_t packets_per_frame =
+                        test::FrameSamples / test::PacketSamples;
                     CHECK(recv_expected_pkts >= send_expected_pkts);
-                    CHECK(recv_expected_pkts <= send_expected_pkts + nlag);
+                    CHECK(recv_expected_pkts
+                          <= send_expected_pkts + packets_per_frame * 5);
                 }
             }
         }

--- a/src/tests/public_api/test_loopback_encoder_2_decoder.cpp
+++ b/src/tests/public_api/test_loopback_encoder_2_decoder.cpp
@@ -303,8 +303,8 @@ TEST_GROUP(loopback_encoder_2_decoder) {
                 UNSIGNED_LONGS_EQUAL(iface_packets[n_if], recv_expected_pkts);
                 if (has_control) {
                     const size_t nlag = test::FrameSamples / test::PacketSamples;
-                    CHECK(recv_expected_pkts >= send_expected_pkts
-                          && recv_expected_pkts <= send_expected_pkts + nlag);
+                    CHECK(recv_expected_pkts >= send_expected_pkts);
+                    CHECK(recv_expected_pkts <= send_expected_pkts + nlag);
                 }
             }
         }


### PR DESCRIPTION
Changes:

- gh-838: Hot fix 4 Ubuntu 26.04: num of SoX drivers exceeds 256 (cherry-pick from master)
- gh-843: Fix macOS CI
- gh-845: Fix use-after-free during slot deletion
- Fix tests under valgrind on CI 
- Add pulseaudio 17 to distfile to fix CI download errors

