### PR TITLE
ci: fix Android CI (emulator create_routes network race + macOS NDK bump)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,10 +294,10 @@ jobs:
           - toolchain: aarch64-linux-android29
             abi: aarch64
             api: 29
-            ndk-major: 21
-            ndk: 21.4.7075529
-            build_tools: 28.0.3
-            cmake: 3.10.2.4988404
+            ndk-major: 25
+            ndk: 25.2.9519653
+            build_tools: 30.0.3
+            cmake: 3.22.1
 
     runs-on: macos-latest
 

--- a/scripts/android_emu/emulator.sh
+++ b/scripts/android_emu/emulator.sh
@@ -31,15 +31,45 @@ if [[ "${action}" == create_routes ]]
 then
     color_msg "creating routes"
 
-    adb shell "ip a" | grep 'state UP' | cut -d':' -f2 | awk '{print $1}' | cut -d'@' -f1 |
-        while read iface
-        do
-            if ! adb shell ip route show table all | \
-                    grep -qF "224.0.0.0/4 dev ${iface} table local"
-            then
-                run_cmd adb shell "su 0 ip route add 224.0.0.0/4 dev ${iface} table local"
-            fi
-        done
+    # Poll for a while to verify that the emulator has network interfaces available
+    ip_output=""
+    for _ in $(seq 1 10)
+    do
+        ip_output="$(adb shell "ip a" 2>/dev/null || true)"
+        if echo "${ip_output}" | grep -q 'state UP'
+        then
+            break
+        fi
+        sleep 2
+    done
+
+    echo "+++ adb shell ip a"
+    echo "${ip_output}"
+
+    # Collect interfaces in state UP. grep returns non-zero when it
+    # find nothing, so guard the pipeline against pipefail to avoid aborting
+    # the whole script when no interface is up.
+    ifaces="$(echo "${ip_output}" \
+        | grep 'state UP' \
+        | cut -d':' -f2 \
+        | awk '{print $1}' \
+        | cut -d'@' -f1 || true)"
+
+    if [[ -z "${ifaces}" ]]
+    then
+        color_msg "warning: no network interface is up, skipping route setup"
+    fi
+
+    # Iterate over a plain variable (not a pipe) so that the "adb" calls inside
+    # the loop do not consume the loop's stdin and skip interfaces.
+    for iface in ${ifaces}
+    do
+        if ! adb shell ip route show table all | \
+                grep -qF "224.0.0.0/4 dev ${iface} table local"
+        then
+            run_cmd adb shell "su 0 ip route add 224.0.0.0/4 dev ${iface} table local"
+        fi
+    done
 fi
 
 if [[ "${action}" == start_avd ]]


### PR DESCRIPTION
Two fixes for the Android CI jobs.

### 1. `android-emu` — `create_routes` network race (`emulator.sh`)

The `android-emu-ndk26/x86_64-android33` job failed in the **Run tests** step at
`scripts/android_emu/emulator.sh create_routes`, exiting 1 immediately after
`--- creating routes` with no further output.

Root cause: the block runs under `set -euo pipefail` and harvested interfaces via
`adb shell "ip a" | grep 'state UP' | ...`. A reported `sys.boot_completed` does
not guarantee any interface has reached `state UP` yet, so `grep` matched nothing,
exited 1, and `pipefail` + `set -e` aborted the whole job before any route was added.

Changes to the `create_routes` action:
- Poll for the emulator network to come up before harvesting interfaces.
- Dump `adb shell ip a` for diagnostics.
- Guard the harvest pipeline against `pipefail` so an empty match warns and
  continues instead of aborting.
- Iterate over a plain variable instead of a pipe, so the in-loop `adb` calls no
  longer consume the loop's stdin and skip interfaces.
- A genuine `su 0 ip route add` failure still hard-fails via `run_cmd`.

### 2. `android-macos` — bump oldest NDK 21 → 25 (`build.yml`)

The oldest tested NDK (21) crashes on the macOS 26 runner image; bump it to 25.
